### PR TITLE
環境設定の外部出し

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,6 @@
+RAILS_MAX_THREADS = DBコネクションプールの上限数
+DB_HOST = DBのホスト名orIPアドレス
+
+DB_NAME = 接続するDataBase名
+DB_USERNAME = 接続するDataBaseのユーザ名'
+DB_PASSWORD = 接続するDataBaseのパスワード'

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,10 @@ yarn-debug.log*
 # to ignore ruby mine
 .idea
 /vendor/*
+
+# to ignore .env file
+/.env
+/.env.development
+/.env.test
+/.env.production
+!/.env.sample

--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'font-awesome-sass'
 gem 'kaminari'
+gem 'dotenv-rails'
 
 # hirb: 出力結果を表形式で出力する
 # hirb-unicode: マルチバイト文字の表示を補正する

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,10 @@ GEM
     devise-i18n (1.9.1)
       devise (>= 4.7.1)
     devise-i18n-views (0.3.7)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     ffi (1.13.1)
     font-awesome-sass (5.13.0)
@@ -270,6 +274,7 @@ DEPENDENCIES
   devise-bootstrap-views (~> 1.0)
   devise-i18n
   devise-i18n-views
+  dotenv-rails
   font-awesome-sass
   hirb
   hirb-unicode

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,20 +2,20 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: 127.0.0.1
-  username: root
+  host: <%= ENV.fetch("DB_HOST") { "127.0.0.1" } %>
+  username: <%= ENV.fetch("DB_USERNAME") { "root" } %>
   # password: root
   # port: 3307
 development:
   <<: *default
-  database: go-to-nago_development
+  database: <%= ENV['DB_NAME'] %>
 
 test:
   <<: *default
-  database: go-to-nago_test
+  database: <%= ENV['DB_NAME'] %>
 
 production:
   <<: *default
-  database: go-to-nago_production
-  username: go-to-nago
-  password: <%= ENV['GO-TO-NAGO_DATABASE_PASSWORD'] %>
+  database: <%= ENV['DB_NAME'] %>
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
 ActiveRecord::Schema.define(version: 2020_05_30_043421) do
-
 
   create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
## 概要

開発環境と本番環境を柔軟に切り替えられるように環境設定の外出しをする。

具体的には.envに設定をだして、default / development / test / production ビルドで動作するようにしてください。

新規参加者もスムーズに導入できるようにSampleファイルを作成する

## ブランチ

feature/bring_out_env_config

## 実施内容

### gem dotenv-railsのインストール

- .envファイルに記載した環境変数がrailsで読み込めるようにするため、`dotenv-rails` gemのインストールを実施



### database.ymlが.envを読み込むように変更

datavase.ymlの環境変数取得先を記載

.env(git管理対象外)および.env.sample(git管理対象)を作成。

## 参考
- [dotenv-railsの導入方法と使い方を理解して環境変数を管理しよう！](https://pikawaka.com/rails/dotenv-rails)
- [ENV[]とENV.fetch()の違い【Rails/Ruby】 - Qiita](https://qiita.com/sukebeeeeei/items/576f109d57218c8397d5)

## 備考

UIの変更なし

### その他

- [x]  変更後のサービス起動＆疎通確認
