### PR TITLE
「マイページ」画面表示時にお気に入りのグルメ一覧を表示

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -66,7 +66,7 @@
     </ul>
     <!-- Tab panes(タブを押したときに表示する中身) -->
     <div class="tab-content pt-3">
-      <div role="tabpanel" class="tab-pane fade" id="gourmet-tab">
+      <div role="tabpanel" class="tab-pane fade active show" id="gourmet-tab">
         <div class="list-wrapper">
           <div class="row " id="gourmet_lists">
             <%=render 'facilities/gourmet_list' %>
@@ -77,7 +77,7 @@
           </div>
         </div>
       </div>
-      <div role="tabpanel" class="tab-pane active fade show" id="facility-tab">
+      <div role="tabpanel" class="tab-pane fade" id="facility-tab">
         <div class="row " id="facility_lists">
           <%=render 'facilities/facility_list' %>
           <div class="list-button col-12">


### PR DESCRIPTION
## 概要

「マイページ」画面表示時の、お気に入り一覧に「グルメ」の一覧が表示されるようにする。
（現状は、「施設」の一覧が表示されている）

## ブランチ

fix/mypage_initial_favorite_view

## 実施内容

- vies/users/show.html.erbの改修
初期表示されるbootstrapクラス(show, active)指定箇所の変更

### その他

- [x]  変更後のサービス起動＆疎通確認
## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->

- before
![スクリーンショット 2020-07-13 0 57 47](https://user-images.githubusercontent.com/36526480/87269588-921ce980-c508-11ea-8c91-a8dfd60cbb98.png)

- after
   ![スクリーンショット 2020-07-13 12 51 14](https://user-images.githubusercontent.com/36526480/87269533-6dc10d00-c508-11ea-8797-126562f9f8a4.png)
