### PR TITLE
ボトムエリア(ソーシャルボタン、情報掲載依頼ボタン）のテンプレート化

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -107,6 +107,40 @@ body,
 .field_with_errors .form-control {
     border: solid 2px #a94442;
 }
+// ---------------最下部のsnsアイコンリスト---------------
+.bottom-sns {
+  text-align: center;
+  margin: 40px auto;
+}
+
+.bottom-sns ul li {
+  display: inline;
+  margin: 20px 30px;
+  font-size: 50px;
+}
+
+.circle {
+  display: inline-block;
+  width: 80px;
+  height: 80px;
+  border-radius: 50%;
+  border: solid 1px #888888;
+  text-align: center;
+  line-height: 80px;
+  border-radius: 50%;
+}
+
+.bottom-sns ul li a {
+  text-decoration: none;
+  color: #888888;
+}
+
+// 最下部の情報修正依頼へのリンク
+.bottom-text {
+  text-align: center;
+  margin: 0 30px 40px 30px;
+}
+
 
 // --------------footer---------------------
 .footer {

--- a/app/assets/stylesheets/main/facilities.scss
+++ b/app/assets/stylesheets/main/facilities.scss
@@ -57,40 +57,6 @@ hr {
   text-decoration: none;
 }
 
-// ---------------最下部のsnsアイコンリスト---------------
-.bottom-sns {
-  text-align: center;
-  margin: 40px auto;
-}
-
-.bottom-sns ul li {
-  display: inline;
-  margin: 20px 30px;
-  font-size: 50px;
-}
-
-.circle {
-  display: inline-block;
-  width: 80px;
-  height: 80px;
-  border-radius: 50%;
-  border: solid 1px #888888;
-  text-align: center;
-  line-height: 80px;
-  border-radius: 50%;
-}
-
-.bottom-sns ul li a {
-  text-decoration: none;
-  color: #888888;
-}
-
-// 最下部の情報修正依頼へのリンク
-.bottom-text {
-  text-align: center;
-  margin: 0 30px 40px 30px;
-}
-
 // ---------------詳細画面CSS---------------
 // 吹き出し　ここから
 .balloon1-top {

--- a/app/views/facilities/bookmark.html.erb
+++ b/app/views/facilities/bookmark.html.erb
@@ -31,17 +31,4 @@
       </div>
     </div>
   </div>
-  <div class="bottom">
-    <div class="bottom-sns">
-      <ul>
-        <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-      </ul>
-    </div>
-    <div class="bottom-text">
-      <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-    </div>
-  </div>
 </div>

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -73,17 +73,5 @@
       <a href="/facility/list" type="button" class="btn btn-primary btn-lg btn-block">もっと見る</a>
     </div>
   </div>
-  <div class="bottom">
-    <div class="bottom-sns">
-      <ul>
-        <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-      </ul>
-    </div>
-    <div class="bottom-text">
-      <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-    </div>
-  </div>
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_add_request: true } %>
 </div>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -153,19 +153,7 @@
     <hr>
     <div class="w-100" id="map" data-facility-latitude="<%= @facility.latitude %>" data-facility-longitude="<%= @facility.longitude %>">google map</div>
   </div>
-  <div class="bottom">
-    <div class="bottom-sns">
-      <ul>
-        <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-      </ul>
-    </div>
-    <div class="bottom-text">
-      <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-    </div>
-  </div>
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_edit_request: true } %>
 </div>
 
 <%

--- a/app/views/facilities/show_facility.html.erb
+++ b/app/views/facilities/show_facility.html.erb
@@ -14,19 +14,5 @@
       </div>
     </div>
   </div>
-
-  <div class="bottom">
-    <div class="bottom-sns">
-      <ul>
-        <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-      </ul>
-    </div>
-    <div class="bottom-text">
-      <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-    </div>
-  </div>
-
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_add_request: true } %>
 </div>

--- a/app/views/facilities/show_gourmet.html.erb
+++ b/app/views/facilities/show_gourmet.html.erb
@@ -14,20 +14,5 @@
       </div>
     </div>
   </div>
-</div>
-
-<div class="bottom">
-  <div class="bottom-sns">
-    <ul>
-      <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-      <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-      <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-      <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-    </ul>
-  </div>
-  <div class="bottom-text">
-    <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-  </div>
-</div>
-
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_add_request: true } %>
 </div>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -31,19 +31,5 @@
       </div>
     </div>
   </div>
-
-  <div class="bottom">
-    <div class="bottom-sns">
-      <ul>
-        <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-      </ul>
-    </div>
-    <div class="bottom-text">
-      <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-    </div>
-  </div>
-
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_edit_request: true } %>
 </div>

--- a/app/views/publics/_bottom_area.html.erb
+++ b/app/views/publics/_bottom_area.html.erb
@@ -1,0 +1,22 @@
+  <div class="bottom">
+    <% if local_assigns[:sns_icon] %>
+      <div class="bottom-sns">
+        <ul>
+          <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
+          <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
+          <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
+          <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
+        </ul>
+      </div>
+    <% end %>
+    <% if local_assigns[:facility_add_request] %>
+      <div class="bottom-text">
+        <button type="button" class="btn btn-primary btn-lg btn-block">情報掲載依頼はこちら</button>
+      </div>
+    <% end %>
+    <% if local_assigns[:facility_edit_request] %>
+      <div class="bottom-text">
+        <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
+      </div>
+    <% end %>
+  </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -92,22 +92,4 @@
       </div>
     </div>
   </div>
-
-
-
-  <div class="bottom">
-    <!-- sns -->
-    <div class="bottom-sns">
-      <ul>
-        <li><a href="#" class="circle"><i class="fab fa-twitter"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-google-plus-g"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-facebook-f"></i></a></li>
-        <li><a href="#" class="circle"><i class="fab fa-instagram"></i></a></li>
-      </ul>
-    </div>
-    <!-- 修正依頼 -->
-    <div class="bottom-text">
-      <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
-    </div>
-  </div>
 </div>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
画面下部のボトムエリア（ソーシャルボタン、情報掲載依頼ボタンを表示）が、各viewファイル(計７ファイル）に記載されており、メンテナンス性が著しく低いので、テンプレート化する。
また、画面設計を確認して、各画面で本来表示されるべきボトムエリアの内容の整理、修正もあわせて実施。

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 現状と本来表示されるべき内容の整理
<img src="https://user-images.githubusercontent.com/36526480/88512638-d8eb0300-d021-11ea-8d4c-95578bf41e6d.png" width="500px">

[整理資料](https://docs.google.com/spreadsheets/d/1VOGUOPeWXst78sDDUrb-33zE5pGAuJfB0CJ9BtiUY7I/edit#gid=0)

- テンプレートファイルの作成
  `app/views/publics/_bottom_area.html.erb`を作成。
   呼び出し側の、変数によって、表示する内容の制御を行う。(local_assignを使用)
-  各viewファイルから、テンプレートの呼び出し
   ボトムエリアの表示を、上記テンプレートを呼び出す('render partial~')ように変更。また、local変数を定義して、表示すべき内容を設定。
- bottom-areaに対する CSSも現状のfacilities.scssから、共通のapplication.scssへ移動

## 変更前後の画像
UIの変更なし

## 参考
https://railsguides.jp/layouts_and_rendering.html#%E3%83%AD%E3%83%BC%E3%82%AB%E3%83%AB%E5%A4%89%E6%95%B0%E3%82%92%E6%B8%A1%E3%81%99