### PR TITLE
情報掲載依頼・修正依頼の機能追加

### DIFF
--- a/app/admin/inquiries.rb
+++ b/app/admin/inquiries.rb
@@ -25,7 +25,7 @@ ActiveAdmin.register Inquiry do
       input :name, input_html: { disabled: true }
       input :email, input_html: { disabled: true }
       input :subject, input_html: { disabled: true }
-      input :message, input_html: { disabled: true }
+      input :message, as: textarea, input_html: { disabled: true }
       input :created_at, as: :string, input_html: { disabled: true }
       input :updated_at, as: :string, input_html: { disabled: true }
     end

--- a/app/admin/inquiries.rb
+++ b/app/admin/inquiries.rb
@@ -4,13 +4,15 @@ ActiveAdmin.register Inquiry do
   # 検索条件パネルの表示項目
   filter :status, as: :select
   # 管理画面で更新できる項目の設定
-  permit_params :status
+  permit_params :status, :admin_comment
 
   index do
     id_column
     column :status
+    column :kind
     column :user_id
     column :name
+    column :facility_id
     column :subject
     column :created_at
     column :updated_at
@@ -21,13 +23,16 @@ ActiveAdmin.register Inquiry do
     inputs "タイトル" do
       input :id,  input_html: { disabled: true }
       input :status, as: :select
+      input :kind, input_html: { disabled: true }
       input :user_id, input_html: { disabled: true }
       input :name, input_html: { disabled: true }
       input :email, input_html: { disabled: true }
+      input :facility_id, input_html: { disabled: true }  
       input :subject, input_html: { disabled: true }
-      input :message, as: textarea, input_html: { disabled: true }
+      input :message, as: :text, input_html: { disabled: true }
       input :created_at, as: :string, input_html: { disabled: true }
       input :updated_at, as: :string, input_html: { disabled: true }
+      input :admin_comment, as: :text
     end
     f.actions
   end

--- a/app/assets/stylesheets/main/inquiries.scss
+++ b/app/assets/stylesheets/main/inquiries.scss
@@ -1,5 +1,6 @@
 .inquiry-area{
   max-width: 700px;
+  width: 70%;
   margin: 3rem auto 3rem;
 }
 

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -1,57 +1,27 @@
 class InquiriesController < ApplicationController
 
-  NEW_SUBJECT = "情報掲載依頼"
-  NEW_MESSAGE = <<-TEXT 
-    情報掲載を希望される施設の情報を、記載してください。
-    ＝＝＝＝＝＝＝＝＝＝＝＝
-    施設名：
-    郵便番号、住所：
-    電話番号：
-    URL:
-    定休日：
-    営業時間：
-    メニュー：
-    駐車場：
-    TEXT
-  EDIT_SUBJECT = "情報修正依頼"
-  EDIT_MESSAGE = <<-TEXT 
-    情報掲載を希望される施設の情報を、記載してください。
-    ＝＝＝＝＝＝＝＝＝＝＝＝
-    修正が必要な項目：
-    正しい情報内容：
-    TEXT
-  
   def new
-    @inquiry = Inquiry.new # unless @inquiry
-    @inquiry.kind = params[:kind].to_i if params[:kind]
-    @inquiry.facility_id = params[:facility_id].to_i  if params[:facility_id]
-    debugger
-    case @inquiry.kind 
-    when "new_facility"
-      @inquiry.subject = NEW_SUBJECT
-      @inquiry.message = NEW_MESSAGE
-    when "edit_facility"
-      facility_name = @inquiry.facility.name
-      @inquiry.subject = EDIT_SUBJECT + "(#{facility_name})"
-      @inquiry.message = EDIT_MESSAGE
-    end
+    kind = params[:kind].present? ? params[:kind].to_i : nil
+    facility_id = params[:facility_id].present? ? params[:facility_id].to_i : nil
+    @inquiry = Inquiry.new
+    @inquiry.default_set(kind, facility_id)
+    # debugger
   end
 
   def confirm
     @inquiry = Inquiry.new(inquiry_params)
-    debugger
+    # debugger
     render :new if @inquiry.invalid?
   end
 
   def create
     @inquiry = Inquiry.new(inquiry_params)
-    debugger
+    # debugger
     # 戻るボタンが押された場合
     if params["back"]
       render :new
     elsif @inquiry.save
       flash.now[:success] = "お問い合わせを受け付けました"
-      # redirect_to root_url
       # メール送信
       # InquiryMailer.send_mail(@inquiry).deliver_later
     else

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -1,10 +1,8 @@
 class InquiriesController < ApplicationController
 
   def new
-    kind = params[:kind].present? ? params[:kind].to_i : nil
-    facility_id = params[:facility_id].present? ? params[:facility_id].to_i : nil
     @inquiry = Inquiry.new
-    @inquiry.default_set(kind, facility_id)
+    @inquiry.default_set(params[:kind], params[:facility_id], current_user)
     # debugger
   end
 
@@ -23,7 +21,7 @@ class InquiriesController < ApplicationController
     elsif @inquiry.save
       flash.now[:success] = "お問い合わせを受け付けました"
       # メール送信
-      # InquiryMailer.send_mail(@inquiry).deliver_later
+      InquiryMailer.send_mail(@inquiry).deliver_later
     else
       flash.now[:danger].now = "お問い合わせ送信に失敗しました"
       render :new

--- a/app/controllers/inquiries_controller.rb
+++ b/app/controllers/inquiries_controller.rb
@@ -1,15 +1,51 @@
 class InquiriesController < ApplicationController
+
+  NEW_SUBJECT = "情報掲載依頼"
+  NEW_MESSAGE = <<-TEXT 
+    情報掲載を希望される施設の情報を、記載してください。
+    ＝＝＝＝＝＝＝＝＝＝＝＝
+    施設名：
+    郵便番号、住所：
+    電話番号：
+    URL:
+    定休日：
+    営業時間：
+    メニュー：
+    駐車場：
+    TEXT
+  EDIT_SUBJECT = "情報修正依頼"
+  EDIT_MESSAGE = <<-TEXT 
+    情報掲載を希望される施設の情報を、記載してください。
+    ＝＝＝＝＝＝＝＝＝＝＝＝
+    修正が必要な項目：
+    正しい情報内容：
+    TEXT
+  
   def new
     @inquiry = Inquiry.new # unless @inquiry
+    @inquiry.kind = params[:kind].to_i if params[:kind]
+    @inquiry.facility_id = params[:facility_id].to_i  if params[:facility_id]
+    debugger
+    case @inquiry.kind 
+    when "new_facility"
+      @inquiry.subject = NEW_SUBJECT
+      @inquiry.message = NEW_MESSAGE
+    when "edit_facility"
+      facility_name = @inquiry.facility.name
+      @inquiry.subject = EDIT_SUBJECT + "(#{facility_name})"
+      @inquiry.message = EDIT_MESSAGE
+    end
   end
 
   def confirm
     @inquiry = Inquiry.new(inquiry_params)
+    debugger
     render :new if @inquiry.invalid?
   end
 
   def create
     @inquiry = Inquiry.new(inquiry_params)
+    debugger
     # 戻るボタンが押された場合
     if params["back"]
       render :new
@@ -17,7 +53,7 @@ class InquiriesController < ApplicationController
       flash.now[:success] = "お問い合わせを受け付けました"
       # redirect_to root_url
       # メール送信
-      InquiryMailer.send_mail(@inquiry).deliver_later
+      # InquiryMailer.send_mail(@inquiry).deliver_later
     else
       flash.now[:danger].now = "お問い合わせ送信に失敗しました"
       render :new
@@ -27,6 +63,8 @@ class InquiriesController < ApplicationController
   private
 
   def inquiry_params
-    params.require(:inquiry).permit(:user_id, :name, :email, :subject, :message)
+    params.require(:inquiry).permit(:user_id, :name, :email, :subject, :message, :kind, :facility_id)
   end
+
+
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -1,5 +1,5 @@
 class Inquiry < ApplicationRecord
-  # belongs_to :user, optional: true, counter_cache: true
+  belongs_to :user, optional: true
   belongs_to :facility, optional: true
   enum status: { not_started: 0, in_progress: 1, done: 9 }, _prefix: true
   enum kind: {inquiry: 0, new_facility:1, edit_facility:2}, _prefix: true

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -1,6 +1,8 @@
 class Inquiry < ApplicationRecord
   # belongs_to :user, optional: true, counter_cache: true
-  enum status: { 未着手: 0, 対応中: 1, 完了: 9 }, _prefix: true
+  belongs_to :facility, optional: true
+  enum status: { not_started: 0, in_progress: 1, done: 9 }, _prefix: true
+  enum kind: {inquiry: 0, new_facility:1, edit_facility:2}, _prefix: true
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :subject, length: { maximum: 100 }
@@ -8,4 +10,5 @@ class Inquiry < ApplicationRecord
   validates :email, presence: true, length: { maximum: 254 },
                     format: { with: VALID_EMAIL_REGEX }
   validates :message, presence: true, length: { maximum: 1000 }
+
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -12,9 +12,9 @@ class Inquiry < ApplicationRecord
   validates :message, presence: true, length: { maximum: 1000 }
 
   NEW_SUBJECT = "情報掲載依頼"
-  NEW_MESSAGE = <<-TEXT 
-    情報掲載を希望される施設の情報を、記載してください。
-    ＝＝＝＝＝＝＝＝＝＝＝＝
+  NEW_MESSAGE = <<~TEXT 
+    情報掲載を希望される施設の情報
+    ---------------------------------
     施設名：
     郵便番号、住所：
     電話番号：
@@ -25,16 +25,16 @@ class Inquiry < ApplicationRecord
     駐車場：
     TEXT
   EDIT_SUBJECT = "情報修正依頼"
-  EDIT_MESSAGE = <<-TEXT 
-    情報掲載を希望される施設の情報を、記載してください。
-    ＝＝＝＝＝＝＝＝＝＝＝＝
+  EDIT_MESSAGE = <<~TEXT 
+    修正が必要な情報
+    ---------------------------------
     修正が必要な項目：
     正しい情報内容：
     TEXT
 
-  def default_set(kind, facility_id)
-    self.kind = kind.to_i
-    self.facility_id = facility_id
+  def default_set(kind, facility_id, current_user=nil)
+    self.kind = kind.to_i if kind
+    self.facility_id = facility_id.to_i if facility_id
     # debugger
     case self.kind 
     when "new_facility"
@@ -44,6 +44,11 @@ class Inquiry < ApplicationRecord
       facility_name = Facility.find(self.facility_id).name
       self.subject = EDIT_SUBJECT + "(#{facility_name})"
       self.message = EDIT_MESSAGE
+    end
+    if current_user
+      self.user_id = current_user.id
+      self.name = current_user.nickname
+      self.email = current_user.email
     end
   end
 end

--- a/app/models/inquiry.rb
+++ b/app/models/inquiry.rb
@@ -11,4 +11,39 @@ class Inquiry < ApplicationRecord
                     format: { with: VALID_EMAIL_REGEX }
   validates :message, presence: true, length: { maximum: 1000 }
 
+  NEW_SUBJECT = "情報掲載依頼"
+  NEW_MESSAGE = <<-TEXT 
+    情報掲載を希望される施設の情報を、記載してください。
+    ＝＝＝＝＝＝＝＝＝＝＝＝
+    施設名：
+    郵便番号、住所：
+    電話番号：
+    URL:
+    定休日：
+    営業時間：
+    メニュー：
+    駐車場：
+    TEXT
+  EDIT_SUBJECT = "情報修正依頼"
+  EDIT_MESSAGE = <<-TEXT 
+    情報掲載を希望される施設の情報を、記載してください。
+    ＝＝＝＝＝＝＝＝＝＝＝＝
+    修正が必要な項目：
+    正しい情報内容：
+    TEXT
+
+  def default_set(kind, facility_id)
+    self.kind = kind.to_i
+    self.facility_id = facility_id
+    # debugger
+    case self.kind 
+    when "new_facility"
+      self.subject = NEW_SUBJECT
+      self.message = NEW_MESSAGE
+    when "edit_facility"
+      facility_name = Facility.find(self.facility_id).name
+      self.subject = EDIT_SUBJECT + "(#{facility_name})"
+      self.message = EDIT_MESSAGE
+    end
+  end
 end

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -153,7 +153,7 @@
     <hr>
     <div class="w-100" id="map" data-facility-latitude="<%= @facility.latitude %>" data-facility-longitude="<%= @facility.longitude %>">google map</div>
   </div>
-  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_edit_request: true } %>
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_edit_request: true, facility_id: @facility.id } %>
 </div>
 
 <%

--- a/app/views/inquiries/confirm.html.erb
+++ b/app/views/inquiries/confirm.html.erb
@@ -1,20 +1,31 @@
 <div class="inquiry-area">
   <div class="inquiry-title-area">
-    <h1>お問い合わせ(確認)</h1>
-    <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
+    <% case @inquiry.kind %>
+    <% when "inquiry" %>
+      <h1>お問い合わせ(確認)</h1>
+      <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
+    <% when "new_facility" %>
+      <h1>情報掲載依頼(確認)</h1>
+      <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
+    <% when "edit_facility" %>
+      <h1>情報修正依頼(確認)</h1>
+      <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
+    <% end %>
   </div>
   <%= form_for @inquiry ,action: '/create', html: {class: 'inquiry-form'} do |f| %>
     <table class="table table-bordered">
       <tr><th>お名前</th><td><%= @inquiry.name%></td></tr>
       <tr><th>メールアドレス</th><td><%= @inquiry.email%></td></tr>
       <tr><th>題名</th><td><%= @inquiry.subject%></td></tr>
-      <tr><th>お問い合わせ内容</th><td><%= @inquiry.message%></td></tr>
+      <tr><th>お問い合わせ内容</th><td><%= simple_format(@inquiry.message) %></td></tr>
     </table>
       <%= f.hidden_field :user_id %>
       <%= f.hidden_field :name %>
       <%= f.hidden_field :email %>
       <%= f.hidden_field :subject %>
       <%= f.hidden_field :message %>
+      <%= f.hidden_field :kind %>
+      <%= f.hidden_field :facility_id %>
     <div class="btn-area">
       <%= f.submit '入力画面へ戻る', class: 'btn btn-lg btn-secondary btn-block', name: 'back' %>
       <%= f.submit '送信する', class: 'btn btn-lg btn-primary btn-block' %>

--- a/app/views/inquiries/create.html.erb
+++ b/app/views/inquiries/create.html.erb
@@ -1,6 +1,13 @@
 <div class="inquiry-area">
   <div class="inquiry-title-area">
-    <h1>お問い合わせ(受付完了)</h1>
+    <% case @inquiry.kind %>
+    <% when "inquiry" %>
+      <h1>お問い合わせ(受付完了）</h1>
+    <% when "new_facility" %>
+      <h1>情報掲載依頼(受付完了）</h1>
+    <% when "edit_facility" %>
+      <h1>情報修正依頼(受付完了）</h1>
+    <% end %>
   </div>
 
 <p>問い合わせありがとうございます。</p>

--- a/app/views/inquiries/new.html.erb
+++ b/app/views/inquiries/new.html.erb
@@ -1,8 +1,19 @@
+<% 
+%>
 
 <div class="inquiry-area">
 <div class="inquiry-title-area">
-  <h1>お問い合わせ(入力)</h1>
-  <p>ご意見・ご要望等、各種お問い合わせは、以下のフォームよりご連絡ください。</p>
+  <% case @inquiry.kind %>
+  <% when "inquiry" %>
+    <h1>お問い合わせ(入力)</h1>
+    <p>ご意見・ご要望等、各種お問い合わせは、以下のフォームよりご連絡ください。</p>
+  <% when "new_facility" %>
+    <h1>情報掲載依頼(入力)</h1>
+    <p>「名護へGO」への情報掲載を希望される施設の情報を、以下のフォームよりご連絡ください。</p>
+  <% when "edit_facility" %>
+    <h1>情報修正依頼(入力)</h1>
+    <p>掲載情報に修正を希望される場合は、以下のフォームよりご連絡ください。</p>
+  <% end %>
 </div>
 
 <%= form_for @inquiry, url: {action: "confirm"}, html: {class: 'inquiry-form'} do |f| %>
@@ -36,7 +47,7 @@
 
   <div class="form-group">
     <%= f.label :subject, "題名"  %>
-    <%= f.text_field :subject, class: 'form-control', value: @inquiry.subject %>
+    <%= f.text_field :subject, class: 'form-control', value:  @inquiry.subject %>
   </div>
 
   <div class="form-group">
@@ -44,6 +55,8 @@
     <%= f.text_area :message, size: '10x10', class: 'form-control', value: @inquiry.message, required: true %>
   </div>
 
+  <%= f.hidden_field :kind, value: @inquiry.kind %>
+  <%= f.hidden_field :facility_id, value: @inquiry.facility_id %>
   <div class="btn-area">
     <%= f.submit '内容を確認する', class: 'btn btn-lg btn-primary btn-block' %>
   </div>

--- a/app/views/inquiries/new.html.erb
+++ b/app/views/inquiries/new.html.erb
@@ -17,31 +17,15 @@
 <%= form_for @inquiry, url: {action: "confirm"}, html: {class: 'inquiry-form'} do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
-  <% if user_signed_in? %>
-      <%= f.hidden_field :user_id, value: current_user.id %>
-  
-    <div class="form-group">
-      <label for="inquiry_name">お名前<span class="badge badge-danger">必須</span></label>
-      <%= f.text_field :name, class: 'form-control', value: current_user.nickname , readonly: true %>
-    </div>
+  <div class="form-group">
+    <label for="inquiry_name">お名前<span class="badge badge-danger">必須</span></label>
+    <%= f.text_field :name, class: 'form-control', value: @inquiry.name, required: true  %>
+  </div>
 
-    <div class="form-group">
-      <%#= f.label :email, html: {メールアドレス<span class="badge badge-danger">必須</span>}"  %>
-      <label for="inquiry_email">メールアドレス<span class="badge badge-danger">必須</span></label>
-      <%= f.text_field :email, class: 'form-control', value: current_user.email, readonly: true %>
-    </div>
-
-  <% else %>
-    <div class="form-group">
-      <label for="inquiry_name">お名前<span class="badge badge-danger">必須</span></label>
-      <%= f.text_field :name, class: 'form-control', value: @inquiry.name, required: true  %>
-    </div>
-    <div class="form-group">
-      <label for="inquiry_email">メールアドレス<span class="badge badge-danger">必須</span></label>
-      <%= f.text_field :email, class: 'form-control', value: @inquiry.email, type: "email" , required: true %>
-    </div>
-  <% end %>
-
+  <div class="form-group">
+    <label for="inquiry_email">メールアドレス<span class="badge badge-danger">必須</span></label>
+    <%= f.text_field :email, class: 'form-control', value: @inquiry.email, type: "email" , required: true %>
+  </div>
 
   <div class="form-group">
     <%= f.label :subject, "題名"  %>
@@ -53,6 +37,7 @@
     <%= f.text_area :message, size: '10x10', class: 'form-control', value: @inquiry.message, required: true %>
   </div>
 
+  <%= f.hidden_field :user_id, value: @inquiry.user_id %>
   <%= f.hidden_field :kind, value: @inquiry.kind %>
   <%= f.hidden_field :facility_id, value: @inquiry.facility_id %>
   <div class="btn-area">

--- a/app/views/inquiries/new.html.erb
+++ b/app/views/inquiries/new.html.erb
@@ -1,5 +1,3 @@
-<% 
-%>
 
 <div class="inquiry-area">
 <div class="inquiry-title-area">
@@ -51,7 +49,7 @@
   </div>
 
   <div class="form-group">
-    <label for="inquiry_message">"お問い合わせ内容<span class="badge badge-danger">必須</span></label>
+    <label for="inquiry_message">お問い合わせ内容<span class="badge badge-danger">必須</span></label>
     <%= f.text_area :message, size: '10x10', class: 'form-control', value: @inquiry.message, required: true %>
   </div>
 

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -31,5 +31,6 @@
       </div>
     </div>
   </div>
-  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_edit_request: true } %>
+  <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_edit_request: true, facility_id: @facility.id } %>
+
 </div>

--- a/app/views/publics/_before_login_header.html.erb
+++ b/app/views/publics/_before_login_header.html.erb
@@ -17,7 +17,7 @@
         <%= link_to 'ログイン', new_user_session_path, class: "nav-link" %>
       </li>
       <li class="nav-item">
-        <%= link_to '問合せ', new_inquiry_path, class: "nav-link" %>
+        <%= link_to '問合せ', new_inquiry_path(kind: 0), class: "nav-link" %>
       </li>
     </ul>
   </div>

--- a/app/views/publics/_bottom_area.html.erb
+++ b/app/views/publics/_bottom_area.html.erb
@@ -11,12 +11,12 @@
     <% end %>
     <% if local_assigns[:facility_add_request] %>
       <div class="bottom-text">
-        <button type="button" class="btn btn-primary btn-lg btn-block">情報掲載依頼はこちら</button>
+        <%= link_to "情報掲載依頼はこちら", new_inquiry_path(kind: 1), class:"btn btn-primary btn-lg btn-block" %>
       </div>
     <% end %>
     <% if local_assigns[:facility_edit_request] %>
       <div class="bottom-text">
-        <button type="button" class="btn btn-primary btn-lg btn-block">情報修正依頼はこちら</button>
+        <%= link_to "情報修正依頼はこちら", new_inquiry_path(kind: 2, facility_id: local_assigns[:facility_id]), class:"btn btn-primary btn-lg btn-block" %>
       </div>
     <% end %>
   </div>

--- a/app/views/publics/_footer.html.erb
+++ b/app/views/publics/_footer.html.erb
@@ -14,7 +14,7 @@
         <a href ="/company" class="text-white btn btn-primary btn-lg btn-block"><p>運営会社</p></a>
       </div>
       <div class="col-6 row-li">
-        <%= link_to new_inquiry_path do %>
+        <%= link_to new_inquiry_path(kind: 0) do %>
           <p>問合せ</p>
         <% end %>
       </div>

--- a/app/views/publics/_header.html.erb
+++ b/app/views/publics/_header.html.erb
@@ -19,7 +19,7 @@
       </li>
       <% end %>
       <li class="nav-item">
-        <%= link_to '問合せ', new_inquiry_path, class: "nav-link" %>
+        <%= link_to '問合せ', new_inquiry_path(kind: 0), class: "nav-link" %>
       </li>
       <li class="nav-item">
         <%= link_to 'ログアウト', destroy_user_session_path, class: "nav-link", method: :delete %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,13 +7,16 @@ ja:
       inquiry:
         id: 問い合わせ番号
         status: ステータス
+        kind: 問い合わせ種類
+        user_id: ユーザーID
         name: お名前
         email: メールアドレス
+        facility_id: 施設ID
         subject: 題名
         message: お問い合わせ内容
         created_at: 問い合わせ受付日時
         updated_at: 問い合わせ更新日時
-        user_id: ユーザーID
+        admin_comment: 管理者コメント
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/db/migrate/20200726153331_add_column_inquiries.rb
+++ b/db/migrate/20200726153331_add_column_inquiries.rb
@@ -1,0 +1,9 @@
+class AddColumnInquiries < ActiveRecord::Migration[6.0]
+  def change
+    add_column :inquiries, :type, :integer
+    add_column :inquiries, :admin_comment, :string
+    add_reference :inquiries, :facility, foreign_key: true
+    add_index :inquiries, :type
+    add_index :inquiries, :status
+  end
+end

--- a/db/migrate/20200726153331_add_column_inquiries.rb
+++ b/db/migrate/20200726153331_add_column_inquiries.rb
@@ -1,9 +1,9 @@
 class AddColumnInquiries < ActiveRecord::Migration[6.0]
   def change
-    add_column :inquiries, :type, :integer
+    add_column :inquiries, :kind, :integer
     add_column :inquiries, :admin_comment, :string
     add_reference :inquiries, :facility, foreign_key: true
-    add_index :inquiries, :type
+    add_index :inquiries, :kind
     add_index :inquiries, :status
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_24_072527) do
+ActiveRecord::Schema.define(version: 2020_07_26_153331) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -112,6 +112,12 @@ ActiveRecord::Schema.define(version: 2020_07_24_072527) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.integer "type"
+    t.string "admin_comment"
+    t.bigint "facility_id"
+    t.index ["facility_id"], name: "index_inquiries_on_facility_id"
+    t.index ["status"], name: "index_inquiries_on_status"
+    t.index ["type"], name: "index_inquiries_on_type"
     t.index ["user_id"], name: "index_inquiries_on_user_id"
   end
 
@@ -155,5 +161,6 @@ ActiveRecord::Schema.define(version: 2020_07_24_072527) do
   add_foreign_key "bookmarks", "facilities"
   add_foreign_key "bookmarks", "users"
   add_foreign_key "facility_genres", "genres"
+  add_foreign_key "inquiries", "facilities"
   add_foreign_key "inquiries", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -112,12 +112,12 @@ ActiveRecord::Schema.define(version: 2020_07_26_153331) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
-    t.integer "type"
+    t.integer "kind"
     t.string "admin_comment"
     t.bigint "facility_id"
     t.index ["facility_id"], name: "index_inquiries_on_facility_id"
+    t.index ["kind"], name: "index_inquiries_on_kind"
     t.index ["status"], name: "index_inquiries_on_status"
-    t.index ["type"], name: "index_inquiries_on_type"
     t.index ["user_id"], name: "index_inquiries_on_user_id"
   end
 


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
「情報掲載依頼」「情報修正依頼」の機能を実装する。
既存の「問合せ」機能を流用しつつ、問い合わせの種類によって、画面表示内容などを変化させる。
※なお、事前確認の結果「情報削除依頼」の機能は設定しない
[設計整理資料](https://docs.google.com/spreadsheets/d/1_3LaIt6jBby83_2I85Cp1gvjrchuJfHb-J0iNNA4dds/edit#gid=0)

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
### view
- 遷移元画面・リンクの設定
    遷移元からのリンクURLに問い合わせの種類(`kind:`)をパラメータに設定。
    「お問合せ」：inquiry,「情報掲載依頼」 :new_facility ,「情報修正依頼」: edit_facility
    また、情報掲載依頼には、店舗IDもパラメータに仕込む `facility_id:`

    リンクの例
```ruby
<%= link_to "情報掲載依頼はこちら", new_inquiry_path(kind: 1) %>
```

- 問合せ画面
    既存の問い合わせ画面を利用。
    問合せ種類`(kind`)によって、タイトル、説明文の表示内容を変更する。

### model&DB
- Inquiry DB
   カラム追加：kind, fackility_id, admin_comment
   外部キー設定: user_id, facility_id

- Inquiry model
    user, facilityに対するアソシエーション設定（belongs_to)を追加 
    問合せ種類(kind)やログイン状態によって、各項目の初期設定を行うメソッド(default_set)を追加

### controller
- Inquiry
newメソッド内で、modelの初期設定メソッド(default_set)を呼び出す


### 管理画面(active admin)
DB追加項目を表示させる。

## 変更前後の画像
- 問合せ種類ごとの各画面のキャプチャ[格納先](https://docs.google.com/spreadsheets/d/1_3LaIt6jBby83_2I85Cp1gvjrchuJfHb-J0iNNA4dds/edit#gid=188933823)
![image](https://user-images.githubusercontent.com/36526480/88751039-c1328c80-d191-11ea-9f85-8d7e9a6488cd.png)

