### PR TITLE
Feature/reset password

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -24,7 +24,7 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
   # end
 
   # The path used after confirmation.
-  def after_confirmation_path_for(resource_name, resource)
+  def after_confirmation_path_for(_resource_name, _resource)
     user_path
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -24,9 +24,9 @@ class Users::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  # def after_resetting_password_path_for(resource)
-  #   super(resource)
-  # end
+  def after_resetting_password_path_for(resource)
+    Devise.sign_in_after_reset_password ? user_path : edit_user_password_path
+  end
 
   # パスワード変更メール送信後のパスを設定
   def after_sending_reset_password_instructions_path_for(resource_name)

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -19,9 +19,9 @@ class Users::PasswordsController < Devise::PasswordsController
   # end
 
   # PUT /resource/password
-  # def update
-  #   super
-  # end
+  def update
+    super
+  end
 
   # protected
 

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
-
 class Users::PasswordsController < Devise::PasswordsController
+  # パスワード再設定時、ルートにリダイレクトしてしまうのを回避
+  prepend_before_action :require_no_authentication, only: [:cancel ]
   # GET /resource/password/new
   # def new
   #   super
@@ -27,8 +28,8 @@ class Users::PasswordsController < Devise::PasswordsController
   #   super(resource)
   # end
 
-  # The path used after sending reset password instructions
-  # def after_sending_reset_password_instructions_path_for(resource_name)
-  #   super(resource_name)
-  # end
+  # パスワード変更メール送信後のパスを設定
+  def after_sending_reset_password_instructions_path_for(resource_name)
+    user_path(resource_name) if is_navigational_format?
+  end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+
 class Users::PasswordsController < Devise::PasswordsController
   # パスワード再設定時、ルートにリダイレクトしてしまうのを回避
-  prepend_before_action :require_no_authentication, only: [:cancel ]
+  prepend_before_action :require_no_authentication, only: [:cancel]
   # GET /resource/password/new
   # def new
   #   super
@@ -24,12 +25,12 @@ class Users::PasswordsController < Devise::PasswordsController
 
   # protected
 
-  def after_resetting_password_path_for(resource)
+  def after_resetting_password_path_for(_resource)
     Devise.sign_in_after_reset_password ? user_path : edit_user_password_path
   end
 
   # パスワード変更メール送信後のパスを設定
-  def after_sending_reset_password_instructions_path_for(resource_name)
-    user_path(resource_name) if is_navigational_format?
+  def after_sending_reset_password_instructions_path_for(_resource_name)
+    user_path if is_navigational_format?
   end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -26,11 +26,11 @@ class Users::PasswordsController < Devise::PasswordsController
   # protected
 
   def after_resetting_password_path_for(_resource)
-    Devise.sign_in_after_reset_password ? user_path : edit_user_password_path
+    Devise.sign_in_after_reset_password ? new_user_session_path : new_user_session_path
   end
 
   # パスワード変更メール送信後のパスを設定
   def after_sending_reset_password_instructions_path_for(_resource_name)
-    user_path if is_navigational_format?
+    new_user_session_path if is_navigational_format?
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,7 +10,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def new
   #   super
   # end
-  
+
   # POST /resource
   def create
     super do                                             # 他はdeviseの機能をそのまま流用する
@@ -18,12 +18,12 @@ class Users::RegistrationsController < Devise::RegistrationsController
       #↓と同じ意味(登録時にメール認証を行わない設定)
       # resource.skip_confirmation!
       # resource.save
-      
+
       # deviseは認証済みかどうかの判断をconfirmed_atに日付が入っているかどうかで判定しているようです。
       # そのため、confirmable機能でメールを送信した上で、confirmed_atに値を入れて自己完結させてる
     end
   end
-  
+
   # GET /resource/edit
   # def edit
   #   super
@@ -32,7 +32,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def edit_password
     @user = current_user
   end
-  
+
   # email 編集ページのためのメソッド
   def edit_email
     resource
@@ -83,7 +83,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def update
   #   super
   # end
-  
+
   # DELETE /resource
   # def destroy
   #   super

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,15 @@
-<p>Hello <%= @resource.email %>!</p>
+<p> <%= @resource.email %>様</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p>パスワード変更に関するメールです。</p>
+<p>以下のリンクからパスワードを変更してください。</p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= link_to 'パスワードを変更する', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>このメールにお心当たりがない場合は無視してください</p>
+
+<hr>
+<p>名護へGO運営事務局</p>
+<p>電話番号：01234567</p>
+<p>住所：沖縄県名護市1234</p>
+<p>email:go-to-nago@example.com</p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,27 @@
-<h2>Change your password</h2>
+<div class="title">
+  <h4 class="text-center">メールアドレスを変更</h4>
+</div>
+<div class="container-login">
+  <div>新しいパスワードを入力してください。</div>
+  <div class="mt-5">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= bootstrap_devise_error_messages!%>
+    <%= f.hidden_field :reset_password_token %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
-
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
+    <div class="form-group mb-3">
+      <%= f.label :password, "パスワード" %><br />
+      <% if @minimum_password_length %>
       <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "新しいパスワードを入力してください" %>
+    </div>
+    <div class="form-group mb-3">
+      <%= f.label :password_confirmation, "パスワード（確認用）" %><br />
+      <%= f.password_field :password_confirmation, autocomplete: "新しいパスワード（確認用）を入力してください" %>
+    </div>
+
+    <%= f.submit "変更する", class:'btn btn-success btn-block' %>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="title">
-  <h4 class="text-center">パスワードを変更</h4>
+  <h4 class="text-center">パスワード再設定</h4>
 </div>
 <div class="container-login">
   <div>新しいパスワードを入力してください。</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -5,20 +5,16 @@
   <div>新しいパスワードを入力してください。</div>
   <div class="mt-5">
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-    <%= render "devise/shared/error_messages", resource: resource %>
     <%= bootstrap_devise_error_messages!%>
     <%= f.hidden_field :reset_password_token %>
 
     <div class="form-group mb-3">
       <%= f.label :password, "パスワード" %><br />
-      <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
-      <% end %>
-      <%= f.password_field :password, autofocus: true, autocomplete: "新しいパスワードを入力してください" %>
+      <%= f.password_field :password, autofocus: true, placeholder: "新しいパスワードを入力してください" ,class:"form-control"%>
     </div>
     <div class="form-group mb-3">
       <%= f.label :password_confirmation, "パスワード（確認用）" %><br />
-      <%= f.password_field :password_confirmation, autocomplete: "新しいパスワード（確認用）を入力してください" %>
+      <%= f.password_field :password_confirmation, placeholder: "新しいパスワード（確認用）を入力してください",class:"form-control" %>
     </div>
 
     <%= f.submit "変更する", class:'btn btn-success btn-block' %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="title">
-  <h4 class="text-center">メールアドレスを変更</h4>
+  <h4 class="text-center">パスワードを変更</h4>
 </div>
 <div class="container-login">
   <div>新しいパスワードを入力してください。</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,24 @@
-<h2>Forgot your password?</h2>
+<div class="title">
+  <h4 class="text-center">パスワード再設定</h4>
+</div>
+<div class="container-login">
+  <p>パスワードを再設定を行います。</p>
+  <p>登録しているメールアドレスを入力してください。</p>
+  <p>入力頂いたメールアドレスの確認のメールを送信します。</p>
+  <div class="mt-5">
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+    <%= bootstrap_devise_error_messages!%>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+    <div class="form-group mb-3">
+      <%= f.label :email %>
+      <%= f.email_field :email, class:'form-control', autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力してください" %>
+    </div>
+    <%= f.submit "変更する", class:'btn btn-success btn-block' %>
+    <%= link_to "マイページヘ戻る", user_path ,class:"btn btn-primary btn-block" %>
+    <% end %>
+    <%= render "devise/shared/links" %>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+  <p>変更の有効期限は24時間です。</p>
+  <p>24時間以内に変更を完了しなかった場合は変更を完了しなかった場合は再度お手続きをお願いします。</p>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -2,22 +2,20 @@
   <h4 class="text-center">パスワード再設定</h4>
 </div>
 <div class="container-login">
-  <p>パスワードを再設定を行います。</p>
+  <p class="mt-4">パスワードを再設定を行います。</p>
   <p>登録しているメールアドレスを入力してください。</p>
   <p>入力頂いたメールアドレスの確認のメールを送信します。</p>
-  <div class="mt-5">
+  <div class="mt-5 mb-5">
     <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
     <%= bootstrap_devise_error_messages!%>
-    <%= render "devise/shared/error_messages", resource: resource %>
 
-    <div class="form-group mb-3">
+    <div class="form-group mb-5">
       <%= f.label :email %>
       <%= f.email_field :email, class:'form-control', autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力してください" %>
     </div>
-    <%= f.submit "変更する", class:'btn btn-success btn-block' %>
+    <%= f.submit "変更する", class:'btn btn-success btn-block mb-3' %>
     <%= link_to "マイページヘ戻る", user_path ,class:"btn btn-primary btn-block" %>
     <% end %>
-    <%= render "devise/shared/links" %>
   </div>
   <p>変更の有効期限は24時間です。</p>
   <p>24時間以内に変更を完了しなかった場合は変更を完了しなかった場合は再度お手続きをお願いします。</p>

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -16,6 +16,10 @@
     <%= f.label "パスワードを確認" %>
     <%= f.password_field :password_confirmation, class:'form-control', autocomplete: "new-password" %>
   </div>
+  <div class="form-group">
+    <%= f.label :current_password %><span class="badge badge-danger">必須</span>
+    <%= f.password_field :current_password, class:'form-control', autocomplete: "current-password" %>
+  </div>
   <%= f.submit "変更する", class:'btn btn-success btn-block' %>
   <%= link_to "マイページヘ戻る", user_path ,class:"a-right" %>
   <% end %>

--- a/app/views/devise/registrations/edit_password.html.erb
+++ b/app/views/devise/registrations/edit_password.html.erb
@@ -1,28 +1,22 @@
 <div class="title">
-    <h4 class="text-center">パスワードを変更</h4>
+  <h4 class="text-center">パスワードを変更</h4>
 </div>
 <div class="container-login">
-    <%= form_for(resource ,as: resource_name, url: users_update_password_path(resource_name), html: { method: :put }) do |f| %>
-        <%= bootstrap_devise_error_messages!%>
-        <div class="form-group ">
-            <%= f.label "新しいパスワード" %>
-            <%= f.password_field :password, class:'form-control', autocomplete: "new-password" %>
-            <% if @minimum_password_length %>
-            <br />
-            <em><%= @minimum_password_length %> characters minimum</em>
-            <% end %>
-        </div>
-        <div class="form-group">
-            <%= f.label "パスワードを確認" %>
-            <%= f.password_field :password_confirmation, class:'form-control', autocomplete: "new-password" %>
-        </div>
-        <hr>
-        <div class="form-group">
-            <%= f.label :current_password %><span class="badge badge-danger">必須</span>
-            <%= f.password_field :current_password, class:'form-control', autocomplete: "current-password" %>
-            <%= link_to "パスワードをお忘れですか？", new_user_password_path,class:"a-right" %>
-        </div>
-        <%= f.submit "変更する", class:'btn btn-success btn-block' %>
-        <%= link_to "マイページヘ戻る", user_path ,class:"a-right" %>
+  <%= form_for(resource ,as: resource_name, url: users_update_password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= bootstrap_devise_error_messages!%>
+  <div class="form-group ">
+    <%= f.label "新しいパスワード" %>
+    <%= f.password_field :password, class:'form-control', autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+    <br />
+    <em><%= @minimum_password_length %> characters minimum</em>
     <% end %>
+  </div>
+  <div class="form-group">
+    <%= f.label "パスワードを確認" %>
+    <%= f.password_field :password_confirmation, class:'form-control', autocomplete: "new-password" %>
+  </div>
+  <%= f.submit "変更する", class:'btn btn-success btn-block' %>
+  <%= link_to "マイページヘ戻る", user_path ,class:"a-right" %>
+  <% end %>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,26 +3,29 @@
 
   <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
 
-      <div class="form-group">
-        <%= f.label :email %><br />
-        <%= f.email_field :email, class:'form-control', autofocus: true, autocomplete: "email" %>
-      </div>
+  <div class="form-group">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, class:'form-control', autofocus: true, autocomplete: "email" %>
+  </div>
 
-      <div class="form-group">
-        <%= f.label :password %><br />
-        <%= f.password_field :password,  class:'form-control', autocomplete: "current-password" %>
-      </div>
+  <div class="form-group">
+    <%= f.label :password %><br />
+    <%= f.password_field :password,  class:'form-control', autocomplete: "current-password" %>
+  </div>
 
-      <% if devise_mapping.rememberable? %>
-        <div class="form-group">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me %>
-        </div>
-      <% end %>
+  <% if devise_mapping.rememberable? %>
+  <div class="form-group">
+    <%= f.check_box :remember_me %>
+    <%= f.label :remember_me %>
+  </div>
+  <% end %>
 
-    <div class="form-group">
-      <%= f.submit "ログインする", class: 'btn btn-primary btn-block' %>
-    </div>
+  <div class="form-group">
+    <%= f.submit "ログインする", class: 'btn btn-primary btn-block' %>
+  </div>
+  <div class="form-group">
+    <%= link_to "パスワードをお忘れですか？", new_user_password_path,class:"a-right" %>
+  </div>
   <% end %>
 
   <%= render "devise/shared/links" %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -23,9 +23,6 @@
   <div class="form-group">
     <%= f.submit "ログインする", class: 'btn btn-primary btn-block' %>
   </div>
-  <div class="form-group">
-    <%= link_to "パスワードをお忘れですか？", new_user_password_path,class:"a-right" %>
-  </div>
   <% end %>
 
   <%= render "devise/shared/links" %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,27 +1,31 @@
 <div class="form-group">
   <%- if controller_name != 'sessions' %>
-    <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-info btn-block' %><br />
+  <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-info btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-    <%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br />
+  <%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
   <% end -%>
 
+  <%
+=begin%>
   <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-    <%= link_to t('.didn_t_receive_confirmation_instructions'), new_user_confirmation_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
+  <%= link_to t('.didn_t_receive_confirmation_instructions'), new_user_confirmation_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
   <% end -%>
 
   <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-    <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
+  <%= link_to t('.didn_t_receive_unlock_instructions'), new_unlock_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
   <% end -%>
+  <%
+=end%>
 
   <%- if devise_mapping.omniauthable? %>
-    <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: 'btn btn-info btn-block' %><br />
-    <% end -%>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+  <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: 'btn btn-info btn-block' %><br />
+  <% end -%>
   <% end -%>
 </div>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -23,8 +23,7 @@ Devise.setup do |config|
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer
   # オーバーライドさせたいクラスのMailerを指定
-  config.mailer = 'Users::Mailer'
-
+  config.mailer = "Users::Mailer"
 
   # Configure the parent class responsible to send e-mails.
   # config.parent_mailer = 'ActionMailer::Base'
@@ -145,7 +144,6 @@ Devise.setup do |config|
   # 認証メールの有効期限を24時間以内に設定
   config.confirm_within = 1.days
 
-
   # If true, requires any email changes to be confirmed (exactly the same way as
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
@@ -221,7 +219,7 @@ Devise.setup do |config|
 
   # When set to false, does not sign a user in automatically after their password is
   # reset. Defaults to true, so a user is signed in automatically after a reset.
-  # config.sign_in_after_reset_password = true
+  config.sign_in_after_reset_password = false
 
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,19 +25,20 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     registrations: "users/registrations",
     confirmations: 'users/confirmations',
+    passwords: 'users/passwords'
   }
 
 
-    # 追加したアクションのルートを定義
-    devise_scope :user do
-      # パスワード編集のルートを設定 
-      get 'users/edit/password' => 'users/registrations#edit_password'
-      put 'users/update/password' => 'users/registrations#update_password'
-      # email編集のルートを設定
-      get 'users/edit/email' => 'users/registrations#edit_email'
-      put 'users/update/email' => 'users/registrations#update_email'
-      get  'users/update/email/confirm' =>'users/registrations#update_email_confirm'
-    end
+  # 追加したアクションのルートを定義
+  devise_scope :user do
+    # パスワード編集のルートを設定
+    get 'users/edit/password' => 'users/registrations#edit_password'
+    put 'users/update/password' => 'users/registrations#update_password'
+    # email編集のルートを設定
+    get 'users/edit/email' => 'users/registrations#edit_email'
+    put 'users/update/email' => 'users/registrations#update_email'
+    get 'users/update/email/confirm' =>'users/registrations#update_email_confirm'
+  end
   # resource
   resource :user, only: [:show] do
     collection do


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
パスワードの再設定機能の実装（メール認証）
## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- メールアドレス入力画面追加
- メールアドレス入力後ルートに行くバグを解決
- メール内容の編集
- パスワード入力画面の追加

## 変更後の画像
以下の①〜⑥の順でパスワードリセットしていきます

<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
①忘れた場合ボタン（パスワード変更画面にある） | ②メールアドレス入力画面
---- | ----
![1](https://user-images.githubusercontent.com/49609075/88832891-6db15480-d20c-11ea-89ea-b2112bbcecb4.png) | ![2](https://user-images.githubusercontent.com/49609075/88832888-6d18be00-d20c-11ea-835c-73b62c130e0c.png)

③メール申請後 | ④メール内容
---- | ----
![4](https://user-images.githubusercontent.com/49609075/88832885-6be79100-d20c-11ea-887e-eac192016913.png) | ![3](https://user-images.githubusercontent.com/49609075/88832887-6c802780-d20c-11ea-9fb0-d3b58fe84be9.png)

⑤パスワード変更画面 | パスワード変更完了画面
---- | ----
![5](https://user-images.githubusercontent.com/49609075/88832881-69853700-d20c-11ea-894d-72de3a7ee550.png) | ![6](https://user-images.githubusercontent.com/49609075/88833524-57f05f00-d20d-11ea-9b44-ad3c8776bc6b.png)