### PR TITLE
sendgirdによるメール送信設定

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,3 +7,6 @@ DB_PASSWORD = 接続するDataBaseのパスワード
 
 API_KEY = TwitterAPIのAPI_key
 API_SECRET = TwitterAPIのAPI_secret_key
+
+SENDGRID_API_KEY = SendGridのAPI-KEY
+MAIL_FROM = 自動送信メールのfromに設定するメールアドレス(ex. test@example.com)

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'jbuilder', '~> 2.7'
 gem 'font-awesome-sass'
 gem 'kaminari'
 gem 'dotenv-rails'
+gem 'sendgrid-ruby'
 
 gem 'omniauth-twitter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -283,6 +283,7 @@ GEM
     ruby-vips (2.0.17)
       ffi (~> 1.9)
     ruby_dep (1.5.0)
+    ruby_http_client (3.5.0)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -297,6 +298,8 @@ GEM
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
+    sendgrid-ruby (6.3.3)
+      ruby_http_client (~> 3.4)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -375,6 +378,7 @@ DEPENDENCIES
   rubocop-rails
   sass-rails (>= 6)
   selenium-webdriver
+  sendgrid-ruby
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/mailers/inquiry_mailer.rb
+++ b/app/mailers/inquiry_mailer.rb
@@ -2,7 +2,7 @@ class InquiryMailer < ApplicationMailer
   def send_mail(inquiry)
     @inquiry = inquiry
     mail(
-      from: "system@example.com",
+      from: ENV.fetch('MAIL_FROM'){ 'test@example.com'},
       to: @inquiry.email,
       subject: "お問い合わせを受け付けました（名護へGO)"
     )

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module GoToNago
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+    config.paths.add "#{Rails.root}/lib", eager_load: true
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -38,6 +38,7 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   config.action_mailer.delivery_method = :letter_opener
+  # config.action_mailer.delivery_method = :sendgrid
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -61,6 +61,7 @@ Rails.application.configure do
   # config.active_job.queue_name_prefix = "go_to_nago_production"
 
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :sendgrid
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -18,7 +18,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
+  config.mailer_sender = ENV.fetch('MAIL_FROM'){ 'test@example.com'}
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer

--- a/config/initializers/sendgrid.rb
+++ b/config/initializers/sendgrid.rb
@@ -1,0 +1,1 @@
+ActionMailer::Base.add_delivery_method :sendgrid, Mail::SendGrid, api_key: ENV['SENDGRID_API_KEY']

--- a/lib/mail/send_grid.rb
+++ b/lib/mail/send_grid.rb
@@ -1,0 +1,17 @@
+class Mail::SendGrid
+  def initialize(settings)
+    @settings = settings
+  end
+
+  def deliver!(mail)
+    from = SendGrid::Email.new(email: mail.from.first)
+    to = SendGrid::Email.new(email: mail.to.first)
+    subject = mail.subject
+    content = SendGrid::Content.new(type: 'text/plain', value: mail.body.raw_source)
+    sg_mail = SendGrid::Mail.new(from, subject, to, content)
+
+    sg = SendGrid::API.new(api_key: @settings[:api_key])
+    response = sg.client.mail._('send').post(request_body: sg_mail.to_json)
+    puts response.status_code
+  end
+end


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
システム自動で配信するメールをSendgridから送信できるように設定した。

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->

- SendGridでAPIキーを取得
SendGridで取得したAPIキーを環境変数から読み込めるようにした
また、送信元メールアドレス(from)を環境変数に設定して環境ごとに変更できるように設定
- gem sendgrid-rubyのインストール
SendGridに対してAPIでメール送信を行うためのgemをインストーる
- sendgridの設定追加
lib配下にSendGrid設定ライブラリーを追加


## 参考

[Rails: SendGrid(Web API)とAction Mailerでメールを送信する｜TechRacho（テックラッチョ）〜エンジニアの「？」を「！」に〜｜BPS株式会社](https://techracho.bpsinc.jp/yamada/2018_12_22/67222)

[sendgrid/sendgrid-ruby](https://github.com/sendgrid/sendgrid-ruby)

## 変更前後の画像
UI変更なし。

## その他
開発環境では、基本的にletter_opnerでメール内容確認することとし（ただし設定を変更することでsendgridによるメール送信も可能）、本番環境ではsendgridでメール送信する設定としている。
