### PR TITLE
スマホ表示時のボタンデザインの改善

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -330,9 +330,15 @@ nav.header{
   }
   p{
     text-align: center;
-    font-size: 20px;
+    font-size: 3vw;
     margin: 0;
-    line-height: 55px;
+    line-height: 3;
     color: #ffffff;  
+  }
+}
+
+@media(min-width: 768px){
+  .footer p{
+    font-size: 24px;
   }
 }

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -30,7 +30,7 @@
       <% end %>
     </div>
     <div class="list-button">
-      <a href="/gourmet/list" type="button" class="button button-blue-border">おすすめグルメをもっと見る</a>
+      <a href="/gourmet/list" class="button button-blue-border">おすすめグルメをもっと見る</a>
     </div>
   </div>
 </div>
@@ -67,7 +67,7 @@
       <% end %>
     </div>
     <div class="list-button">
-      <a href="/facility/list" type="button" class="button button-white-border">観光スポットをもっと見る</a>
+      <a href="/facility/list" class="button button-white-border">観光スポットをもっと見る</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 目的
スマホ表示時にボタンデザインが崩れていたため改善を実施。
また、スマホ表示のフッターのフォントが大きすぎたため、同様に改善

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- スマホ表示時にボタンデザインの改善
type="button"を適用すると、スマホ側のデフォルトデザインが適用されてしまったため、ボタンリンクから、type="button"を外す
- スマホ表示のフッターのフォントの改善
スマホ表示時にはフッターのフォントサイズを固定サイズから、画面幅に応じた可変長へ変更

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
### スマホ表示時にボタンデザインの改善
- iOS(ipad safari)

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/90228025-7fbc0580-de50-11ea-804a-827e6762c841.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/90228052-89456d80-de50-11ea-8100-0cea1692e3d9.png" width="320"/>
<img src="https://user-images.githubusercontent.com/36526480/90228036-83e82300-de50-11ea-94d4-e9c3f0e5b198.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/90228059-8c405e00-de50-11ea-9fcc-48d866faaf08.png" width="320"/>

- Android(Xperia chrome)

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/90228399-1d173980-de51-11ea-9adc-7a366cafff6f.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/90228419-299b9200-de51-11ea-8be1-25b45006cfc9.png" width="320"/>
<img src="https://user-images.githubusercontent.com/36526480/90228401-1f799380-de51-11ea-8b9a-264242a85a04.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/90228430-2c968280-de51-11ea-80e4-9bc3a5029b70.png" width="320"/>

### スマホ表示のフッターのフォントの改善

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/90227124-0839a680-de4f-11ea-8750-245fdfbdc32d.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/90227250-35865480-de4f-11ea-8635-b76d8db2e2d2.png" width="320"/>
