### PR TITLE
google maps api keyの取得と環境変数設定

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -10,3 +10,5 @@ API_SECRET = TwitterAPIのAPI_secret_key
 
 SENDGRID_API_KEY = SendGridのAPI-KEY
 MAIL_FROM = 自動送信メールのfromに設定するメールアドレス(ex. test@example.com)
+
+GOOGLE_MAPS_API_KEY = GoogleMapsのAPI−KEY  (開発環境用 AIzaSyBVe-mtM8yc1jKrhAS7QkP4k4d8CFua7cU )

--- a/.env.sample
+++ b/.env.sample
@@ -11,4 +11,4 @@ API_SECRET = TwitterAPIのAPI_secret_key
 SENDGRID_API_KEY = SendGridのAPI-KEY
 MAIL_FROM = 自動送信メールのfromに設定するメールアドレス(ex. test@example.com)
 
-GOOGLE_MAPS_API_KEY = GoogleMapsのAPI−KEY  (開発環境用 AIzaSyBVe-mtM8yc1jKrhAS7QkP4k4d8CFua7cU )
+GOOGLE_MAPS_API_KEY = GoogleMapsのAPI−KEY  

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -169,9 +169,9 @@ google mapを呼び出すjavascript
 
   function initMap() {
     geocoder = new google.maps.Geocoder()
-    console.log(latitude)
-    console.log(longitude)
-    console.log(e)
+    // console.log(latitude)
+    // console.log(longitude)
+    // console.log(e)
     map = new google.maps.Map(document.getElementById('map'), {
       center: {
         lat: latitude,
@@ -189,4 +189,4 @@ google mapを呼び出すjavascript
     });
   }
 </script>
-<script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCUDWh0IQXOK7XmXrogmszMGQbagbQbvzU&callback=initMap" async defer></script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAPS_API_KEY'] %>&callback=initMap" async defer></script>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
これまでソースにハードコーティングされていたGoogle Maps API KEYは本番環境では利用できなかったため、
名護へGOのgoogleアカウントで取得したAPI KEYを使用するとともに、API KEYを環境変数に記載してgit管理対象外とする。

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
-  名護へGOのgoogleアカウントでGoogle map API keyの取得(github管理対象外、Readmineに記載）
-  API-KEYの環境変数管理に外だし(git管理対象外とする）
