### PR TITLE
施設オーナーのプロフィール画像の表示修正

### DIFF
--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -26,7 +26,7 @@
     <hr>
     <div class="owner">
       <%if @facility.user.image? %>
-      <%= image_tag("/facility_image/"+@facility.user.image ,class:"text-center rounded-circle" ,alt:"...",style:"width:200px;")  %>
+      <%= image_tag(@facility.user.image.url ,class:"text-center rounded-circle" ,alt:"...",style:"width:200px;")  %>
       <% else%>
       <%= image_tag("title.png" ,class:"text-center rounded-circle" ,alt:"...",style:"width:200px;")  %>
       <% end %>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
施設オーナーのプロフィール画像の表示修正

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 画像表示部分をcarrierwaveの表示メソッドを使用したロジックに修正

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/92202478-12811a80-eeba-11ea-95a2-1db2a3f56cb1.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/92202514-2a589e80-eeba-11ea-92c9-6b7fe3b99430.png" width="320"/>

