### PR TITLE
ユーザーの誕生年はdatetimeでなくてintで良い #150

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -6,6 +6,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # 上書きすることでresourceがうまく渡せるように（defaultのbefore_actionが原因）
   prepend_before_action :authenticate_scope!, only: %i[edit edit_password edit_email update update_password update_email destroy]
   prepend_before_action :set_minimum_password_length, only: %i[new edit edit_password]
+  before_action :setting_birth_year, only: %i[new edit]
+
   # GET /resource/sign_up
   # def new
   #   super
@@ -145,4 +147,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # def after_inactive_sign_up_path_for(resource)
   #   super(resource)
   # end
+
+  def setting_birth_year
+    @birth_year = []
+    for year in (1950..DateTime.now.year).reverse_each do
+      @birth_year << year
+    end
+  end
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -13,7 +13,7 @@
 
   <div class="form-group">
     <%= f.label :birth_year %>
-    <%= f.date_select :birth_year, {discard_day: true, discard_month: true, start_year: Time.now.year, end_year: 1950, prompt: "生まれた年を選択してください"}, class: "form-control" %>
+    <%= f.select :birth_year, @birth_year, {include_blank: "生まれた年を選択してください"}, class: "form-control" %>
   </div>
 
   <div class="form-group">
@@ -40,4 +40,4 @@
     <%= f.submit "プロフィールを変更する", class:'btn btn-success btn-block' %>
   </div>
   <% end %>
-  <%= link_to "マイページヘ戻る", user_path ,class:"btn btn-primary btn-block" %>       
+  <%= link_to "マイページヘ戻る", user_path ,class:"btn btn-primary btn-block" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -16,7 +16,7 @@
 
       <div class="form-group">
         <%= f.label :birth_year %>
-        <%= f.date_select :birth_year, {discard_day: true, discard_month: true, start_year: Time.now.year, end_year: 1950, prompt: "生まれた年を選択してください"}, class: "form-control" %>
+        <%= f.select :birth_year, @birth_year, {include_blank: "生まれた年を選択してください"}, class: "form-control" %>
       </div>
 
       <div class="form-group">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -16,7 +16,7 @@
         <div class="list-content">
           <h3><%=@user.nickname%></h3>
           <!-- 誕生日から年齢を計算 -->
-          <p><%= (Date.today.strftime('%Y%m%d').to_i - @user.birth_year.strftime('%Y%m%d').to_i) / 10000%></p>
+          <p><%= (Date.today.year.to_i - @user.birth_year.to_i) %></p>
           <p><%=@user.sex%></p>
           <p><%=@user.prefecture%></p>
         </div>

--- a/db/migrate/20200904214709_change_data_type_birth_year_of_users.rb
+++ b/db/migrate/20200904214709_change_data_type_birth_year_of_users.rb
@@ -1,0 +1,5 @@
+class ChangeDataTypeBirthYearOfUsers < ActiveRecord::Migration[6.0]
+  def change
+    change_column :users, :birth_year, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_29_133016) do
+ActiveRecord::Schema.define(version: 2020_09_04_214709) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "namespace"
@@ -139,7 +139,7 @@ ActiveRecord::Schema.define(version: 2020_08_29_133016) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "nickname", null: false
-    t.datetime "birth_year", null: false
+    t.integer "birth_year", null: false
     t.integer "sex"
     t.integer "prefecture", null: false
     t.string "image"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,7 @@
 User.find_or_create_by!(email: "test@example.com") do |user|
   user.password = "password"
   user.nickname = "test_user"
-  user.birth_year = DateTime.now
+  user.birth_year = DateTime.now.year
   user.prefecture = 1
   user.sex = 0
   user.status = 1
@@ -11,7 +11,7 @@ puts "ユーザー投入成功"
 User.find_or_create_by!(email: "test2@example.com") do |user|
   user.password = "password"
   user.nickname = "test_user2"
-  user.birth_year = DateTime.now
+  user.birth_year = DateTime.now.year
   user.prefecture = 1
   user.sex = 0
   user.status = 1
@@ -25,7 +25,7 @@ puts "管理者投入成功"
 User.find_or_create_by!(email: "test3@example.com") do |user|
   user.password = "password"
   user.nickname = "test_user3"
-  user.birth_year = DateTime.now
+  user.birth_year = DateTime.now.year
   user.prefecture = 1
   user.sex = 0
   user.status = 1

--- a/test/models/inquiry_test.rb
+++ b/test/models/inquiry_test.rb
@@ -18,7 +18,7 @@ class InquiryTest < ActiveSupport::TestCase
       email: "user@example.text",
       password: "hogehoge",
       nickname: "hoge",
-      birth_year: "2020-07-16 02:34:34",
+      birth_year: 2020,
       prefecture: 1,
       role: 0,
       status: 1


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
ユーザーの誕生年(birth_year)をdatetimeからintegerに変更

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- birth_yearカラムのデータ型をdatetimeからintegerに変更
- birth_yearの入力フォームを修正(1950〜今年までのintegerの配列を作成(降順))
- db:seed及びテスト項目で設定するbirth_yearのパラメータをdatatimeからintegerに修正

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="" width="320"/> | <img src="" width="320"/>
