### PR TITLE
画像格納先をS3へ変更

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,3 +12,7 @@ SENDGRID_API_KEY = SendGridのAPI-KEY
 MAIL_FROM = 自動送信メールのfromに設定するメールアドレス(ex. test@example.com)
 
 GOOGLE_MAPS_API_KEY = GoogleMapsのAPI−KEY  
+
+AWS_S3_BUCKET = S3のバケット名
+AWS_ACCESS_KEY_ID = AWSのアクセスキー
+AWS_SECRET_ACCESS_KEY = AWSのシークレットアクセスキー

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'dotenv-rails'
 gem 'sendgrid-ruby'
 
 gem 'omniauth-twitter'
+gem 'fog-aws'
 
 
 # hirb: 出力結果を表形式で出力する

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,9 +113,27 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
+    excon (0.76.0)
     ffi (1.13.1)
+    fog-aws (3.6.7)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.0)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
     font-awesome-sass (5.13.0)
       sassc (>= 1.11)
+    formatador (0.2.5)
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
@@ -141,6 +159,7 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.0, < 6.1)
       responders (>= 2, < 4)
+    ipaddress (0.8.3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
     jquery-rails (4.4.0)
@@ -176,12 +195,16 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (1.0.0)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2020.0512)
     mimemagic (0.3.5)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.1)
     msgpack (1.3.3)
+    multi_json (1.15.0)
     mysql2 (0.5.3)
     nio4r (2.5.2)
     nokogiri (1.10.9)
@@ -381,6 +404,7 @@ DEPENDENCIES
   devise-i18n
   devise-i18n-views
   dotenv-rails
+  fog-aws
   font-awesome-sass
   gretel
   hirb

--- a/app/uploaders/default_uploader.rb
+++ b/app/uploaders/default_uploader.rb
@@ -4,8 +4,12 @@ class DefaultUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+    # storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/app/uploaders/user_image_uploader.rb
+++ b/app/uploaders/user_image_uploader.rb
@@ -4,8 +4,12 @@ class UserImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :file
-  # storage :fog
+  if Rails.env.production?
+    storage :fog
+  else
+    storage :file
+    # storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,0 +1,22 @@
+require 'carrierwave/storage/abstract'
+require 'carrierwave/storage/file'
+require 'carrierwave/storage/fog'
+
+
+CarrierWave.configure do |config|
+  if Rails.env.production?
+  # if Rails.env.development?
+    config.storage :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_directory = ENV['AWS_S3_BUCKET']
+    config.fog_credentials = {
+      provider: 'AWS',
+      # use_iam_profile: true,
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      region: 'ap-northeast-1'
+    }
+  else
+    config.storage = :file
+  end
+end


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
画像格納先をローカル環境からAWS S3へ変更(本番環境のみ）
※開発環境、テスト環境は従前どおりローカル環境へ格納

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
### fog-aws gemをインストール(`Gemfile`)
fog-awsはRubyのクラウドサービス接続ライブラリ(fog)のAWS特化版

### carrierwaveの設定ファイルを作成
本番環境の場合、前述のfogを使用し、かつ接続に必要なS3,AWS-KEY等の情報を設定する(`carrierwave.rb`)
※現状AWSアクセスキー,AWSシークレットキーを使う設定になっているが、IAMプロファイル設定を使うことで、不要になる想定なので、本番環境接続後に試す。

### ImageUploaderに使用するstorage設定の変更(`default_uploader.rb, user_uploader.rb  `)

storage(保存先）をfileからfogへ変更

### AWS S3のバケット作成＆ポリシー追加(AWS S3コンソールで実施)

### 環境設定ファイルにAWSアクセスキーの設定追加(.env.sample)
## 変更前後の画像
UIの変更なし

## 影響確認
- （一時的に）開発環境の画像格納先をS3へ変更して、アクセスキー、バケットIDを使用して画像の登録、参照が行えること
  登録：初期データImport処理、管理者画面からの登録
  参照：ユーザ参照画面、管理者画面
 ※確認完了後、開発環境の画像格納先はローカル環境へ戻した。