### PR TITLE
S3接続時の認証をIAMプロファイルに変更

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,5 +14,4 @@ MAIL_FROM = 自動送信メールのfromに設定するメールアドレス(ex.
 GOOGLE_MAPS_API_KEY = GoogleMapsのAPI−KEY  
 
 AWS_S3_BUCKET = S3のバケット名
-AWS_ACCESS_KEY_ID = AWSのアクセスキー
-AWS_SECRET_ACCESS_KEY = AWSのシークレットアクセスキー
+

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -11,9 +11,9 @@ CarrierWave.configure do |config|
     config.fog_directory = ENV['AWS_S3_BUCKET']
     config.fog_credentials = {
       provider: 'AWS',
-      # use_iam_profile: true,
-      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
+      use_iam_profile: true,
+      # aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      # aws_secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'],
       region: 'ap-northeast-1'
     }
   else


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
本番環境のS3接続時の認証を、AWSアクセスキーから、IAMプロファイルを使用する方式に変更

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- carrierwaveの設定ファイルで定義している、fog_credentialsの設定をIAMプロファイルを使用(`use_iam_profile`)に変更
- 不要となった、AWSアクセスキーを`.env`ファイルから削除。
