### PR TITLE
ヘッダーの最大幅を設定

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -144,7 +144,8 @@ a:hover {
 // ========ここから（ヘッダー部）=========
 nav.header{
   background-color: #fff;
-  // max-width: 100%;
+  max-width: 1140px;
+  margin: 0 auto;
   width: 100vw;
   padding: 0 1rem;
 }


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
画面幅が大きいディスプレイでもヘッダーが間延びしないように最大幅を設定

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- headerに対してmax-widthを適用 


## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/93761317-8f491e00-fc48-11ea-8521-d60192718c21.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/93761267-77719a00-fc48-11ea-8364-7ed4658b8ba4.png" width="320"/>

![image]()
