### PR TITLE
ユーザのプロフィール画像が楕円表示になる #214

### DIFF
--- a/app/assets/stylesheets/main/users.scss
+++ b/app/assets/stylesheets/main/users.scss
@@ -1,12 +1,14 @@
 .user-image {
   width: 150px;
-  border-radius: 9999px;
+  height: 150px;
+  border-radius: 50%;
   margin-right: 15px;
 }
 
 .non-user-image {
   width: 150px;
-  border-radius: 9999px;
+  height: 150px;
+  border-radius: 50%;
   margin-right: 15px;
 }
 


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
「ユーザのプロフィール画像が楕円表示になる #214」の修正

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- ユーザー画像を正円で表示する様に修正(画像イメージ縦横 150px 固定)

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
![スクリーンショット 2020-09-22 13 04 51](https://user-images.githubusercontent.com/61322479/93843807-1a242a00-fcd6-11ea-9b1d-f63ec82501d9.png)
 | 
![スクリーンショット 2020-09-22 13 05 15](https://user-images.githubusercontent.com/61322479/93843812-201a0b00-fcd6-11ea-9a74-b2479b07cdd2.png)

<img src="" width="320"/> | <img src="" width="320"/>
