### PR TITLE
メールアドレス変更時に「会員登録が完了しました。」と表示される #240

### DIFF
--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -24,7 +24,11 @@ class Users::ConfirmationsController < Devise::ConfirmationsController
     yield resource if block_given?
     if resource.errors.empty?
       # ここの部分
-      flash[:success] = "会員登録が完了しました。"
+      if params[:mail_update] == "1"
+        flash[:success] = "メールアドレスの変更が完了しました。"
+      else
+        flash[:success] = "会員登録が完了しました。"
+      end
       sign_in(@user, bypass: true)
       respond_with_navigational(resource) { redirect_to after_confirmation_path_for(resource_name, resource) }
     else

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -14,7 +14,7 @@
     <p>
       以下のURLをクリックして、メールアドレス変更手続きを完了してください。
       <br>
-      <%= link_to 'メールアドレスの変更を承認する', {controller: "users/confirmations", action: :create,confirmation_token: @token}, method: :post %>
+      <%= link_to 'メールアドレスの変更を承認する', {controller: "users/confirmations", action: :create,confirmation_token: @token, mail_update: 1}, method: :post %>
       <br>
       <br>
       このURLの有効期限は24時間です。


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
「メールアドレス変更時に「会員登録が完了しました。」と表示される #240」の修正

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- メールアドレス変更時のURLにパラメータ「mail_update」を追加し、メールアドレス変更時のリンクから遷移した事を区別。
- メールアドレス変更時のflashメッセージの作成

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="" width="320"/> | <img src="" width="320"/>
---- | ![スクリーンショット 2020-10-01 5 38 33](https://user-images.githubusercontent.com/61322479/94737583-0731e980-03a9-11eb-9dab-69d31947dabb.png)

## 影響範囲
- ユーザー会員本登録時の遷移
- メールアドレス変更時の遷移