### PR TITLE
画面の調整（追加分）（共通＆トップ）

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,5 @@
 
 @import "common";
 @import "main/*";
+
+@import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap');

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -142,16 +142,28 @@ a:hover {
 
 
 // ========ここから（ヘッダー部）=========
-nav.header{
+.header{
   background-color: #fff;
+}
+
+nav.navbar{
   max-width: 1140px;
   margin: 0 auto;
   width: 100vw;
   padding: 0 1rem;
 }
 
-.header-icon-area,.logo-area{
+.menu-icon-area,.logo-area, .account-icon-area{
   height: 55px;
+}
+
+@media(min-width: 768px){
+  .menu-icon-area,.logo-area, .account-icon-area{
+    height: 72px;
+  }
+  .account-icon-area{
+    order: 3;
+  }
 }
 
 @media(min-width: 768px){
@@ -160,18 +172,11 @@ nav.header{
   }
 }
 
-
-@media(min-width: 768px){
-  .header-icon-area,.logo-area{
-    height: 72px;
-  }
-}
-
 .navbar-toggler{
   border: none !important;
 }
 
-.header-icon-area{
+.menu-icon-area, .account-icon-area{
   text-align: center;
   position: relative;
   // height: 100%;

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -5,7 +5,8 @@ $gray-color: #7C7B7B;
 
 body {
   color: #082b48;
-  font-family: Verdana, Geneva, Tahoma, sans-serif;
+  // font-family: 'Noto Sans JP', Verdana, Geneva, Tahoma, sans-serif;
+  font-family: 'Noto Sans JP', sans-serif !important;
   line-height: 1.5;
 }
 
@@ -24,6 +25,17 @@ a {
 
 a:hover {
   opacity: 0.7;
+}
+
+.list-title h3{
+  font-weight: bold;
+  font-size: 1.0rem;
+}
+
+@media(min-width: 768px){
+  .list-title h3{
+    font-size: 24px;
+  }
 }
 
 .container {
@@ -77,15 +89,15 @@ a:hover {
 }
 
 .button{
-  width: 75vw;
-  max-width: 580px;
-  margin: auto;
-  font-size: 3vw;
+  width: 100%;
+  max-width: 576px;
+  margin: 10px auto 0;
+  font-size: 1.0rem;
   font-weight: bold;
   text-decoration: none;
   display: block;
   text-align: center;
-  padding: 15px 0 15px;
+  padding: 8px 0;
   &:hover{
     text-decoration: none;
   }
@@ -133,10 +145,11 @@ a:hover {
   }
 }
 
-// -------------- アイコン  ----------------
-.icon-red{
-  color: $red-color;
-}
+// // -------------- アイコン  ----------------
+// .favorite-icon{
+//   font-size: 0.8rem;
+//   color: $red-color;
+// }
 
 // ========ここまで（共通スタイル）=========
 
@@ -279,16 +292,18 @@ nav.navbar{
 .field_with_errors .form-control {
     border: solid 2px #a94442;
 }
-// ---------------最下部のsnsアイコンリスト---------------
+// ---------------ボトムエリア（SNSアイコンとボタン）---------------
 .bottom{
-  margin: 20px auto;
+  margin: 20px auto 0;
 }
 
 .bottom-sns-area {
   display: flex;
   justify-content: space-around;
   text-align: center;
-  margin: 0 auto 30px;
+  margin: 0 auto;
+  width: 90%;
+  max-width: 576px;
   a:hover{
     text-decoration: none;
   }
@@ -296,22 +311,25 @@ nav.navbar{
 
 .sns-logo {
   text-align: center;
-  width: 4rem;
-  height: 4rem;
+  width: 3rem;
+  height: 3rem;
   border-radius: 50%;
 }
 
 @media(min-width: 768px){
   .sns-logo{
-    width: 5rem;
-    height: 5rem;  
+    width: 4rem;
+    height: 4rem;  
   }
 }
 
+.bottom-button{
+  margin-top: 5px;
+}
 
 // --------------footer---------------------
 .footer {
-  margin-top: auto;
+  margin-top: 20px;
   color:#ffffff;
   background-color: $main-color;
   background-image: image-url('img_yanbaru_inverse.svg'),image-url('img_yanbaru.svg'); 
@@ -322,7 +340,8 @@ nav.navbar{
     margin: 0 -15px;
     .row-li{
       padding: 0;
-      border: 1px solid #ffffff;          
+      border-bottom: 1px solid #ffffff;          
+      border-right: 1px solid #ffffff;          
     }
   }
   a {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -38,8 +38,8 @@ a:hover {
 }
 
 @media(min-width: 768px){
-  .list-title h3{
-    font-size: 24px;
+  .list-title h1{
+    font-size: 2rem;
   }
 }
 
@@ -217,7 +217,7 @@ nav.navbar{
   text-align: center;
   position: relative;
   // height: 100%;
-  width: 40%;
+  width: 30%;
 }
 
 .header-logo{

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -27,9 +27,14 @@ a:hover {
   opacity: 0.7;
 }
 
-.list-title h3{
-  font-weight: bold;
-  font-size: 1.0rem;
+.list-title {
+  width: 85%;
+  margin: 0 auto 30px;
+  text-align: center;
+  h1{
+   font-weight: bold;
+   font-size: 1.2rem;
+ }
 }
 
 @media(min-width: 768px){

--- a/app/assets/stylesheets/main/facilities.scss
+++ b/app/assets/stylesheets/main/facilities.scss
@@ -9,8 +9,8 @@ hr {
 }
 
 .list-wrapper .show-row-list {
-  padding: 7.5px;
-  margin-bottom: 10px;
+  padding: 0 7.5px 7.5px;
+  margin-bottom: 0px;
 }
 
 @media(min-width: 992px) {
@@ -20,9 +20,8 @@ hr {
 }
 
 .list-body {
-  margin-bottom: 30px;
   padding-top: 40px;
-  padding-bottom: 50px;
+  padding-bottom: 30px;
 }
 
 @media(min-width: 992px) {
@@ -36,10 +35,6 @@ hr {
   width: 85%;
   margin: 0 auto 30px;
   text-align: center;
-
-  h3 {
-    font-weight: bold;
-  }
 }
 
 .bg-image-spot {
@@ -66,28 +61,37 @@ hr {
   }
 }
 
+.card-body {
+  padding: 5px !important;
+}
+
 .card-title {
+  height: 2.4rem;
   font-weight: bold;
-  font-size: 1.2rem;
+  font-size: 1.0rem;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
   overflow: hidden;
 }
 
-.card-body {
-  padding: 0.6rem !important;
-}
-
-
 .card-text {
-  font-size: 1.0rem;
+  height: 3.6rem;
+  font-size: 0.8rem;
   color: $gray-color;
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 3;
   overflow: hidden;
+  margin-bottom: 0;
 }
 
 .favorite-area {
-  font-size: 1.5rem;
+  padding: 0 5px 0;
+  a{
+    font-size: 0.8rem;
+    color: $red-color;
+  }
 }
 
 .list-cd {
@@ -113,10 +117,10 @@ hr {
   color: black;
 }
 
-.list-button {
-  text-align: center;
-  margin-top: 50px;
-}
+// .list-button {
+//   text-align: center;
+//   margin-top: 50px;
+// }
 
 // page-nation のもっと見るボタン
 .more a {

--- a/app/assets/stylesheets/main/facilities.scss
+++ b/app/assets/stylesheets/main/facilities.scss
@@ -31,11 +31,6 @@ hr {
 }
 
 
-.list-title {
-  width: 85%;
-  margin: 0 auto 30px;
-  text-align: center;
-}
 
 .bg-image-spot {
   background-image: image-url('bk_spot.png');
@@ -73,6 +68,7 @@ hr {
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
   overflow: hidden;
+  margin-bottom: 0.3rem !important;
 }
 
 .card-text {

--- a/app/assets/stylesheets/main/facilities.scss
+++ b/app/assets/stylesheets/main/facilities.scss
@@ -21,9 +21,16 @@ hr {
 
 .list-body {
   margin-bottom: 30px;
-  padding-top: 100px;
+  padding-top: 40px;
   padding-bottom: 50px;
 }
+
+@media(min-width: 992px) {
+  .list-body {
+    padding-top: 100px;
+  }
+}
+
 
 .list-title {
   width: 85%;
@@ -44,6 +51,7 @@ hr {
 
 .triangle-cut {
   position: relative;
+  padding-top: 100px;
 
   &::before {
     content: "";

--- a/app/views/facilities/_bookmark.html.erb
+++ b/app/views/facilities/_bookmark.html.erb
@@ -1,2 +1,5 @@
-<%= link_to icon('fas', 'heart'), facility_bookmarks_path(facility.id), method: :delete , remote: true , id:"js-bookmark-button-for-facility-#{facility.id}", class:"icon-red" %>
-<%= facility.bookmarks.count %>
+<%= link_to facility_bookmarks_path(facility.id), method: :delete , remote: true , id:"js-bookmark-button-for-facility-#{facility.id}", class:"favorite-icon" do %>
+  <%= icon('fas', 'heart')  %>
+  &nbsp;
+  <%= facility.bookmarks.count %>
+<% end %>

--- a/app/views/facilities/_facilities_list.html.erb
+++ b/app/views/facilities/_facilities_list.html.erb
@@ -17,8 +17,13 @@
         </div>
         <% else%>
         <div class="favorite-area">
-          <object ect><%= link_to icon('far', 'heart'), new_user_session_path, class:"icon-red" %></object>
-          <%= facility.bookmarks.count %>
+          <object ect>
+            <%= link_to new_user_session_path, class:"icon-red" do %>
+              <%= icon('far', 'heart') %>
+              &nbsp;
+              <%= facility.bookmarks.count %>
+            <% end %>
+          </object>
         </div>
         <% end %>
       </div>

--- a/app/views/facilities/_unbookmark.html.erb
+++ b/app/views/facilities/_unbookmark.html.erb
@@ -1,2 +1,5 @@
-<%= link_to icon('far', 'heart'), facility_bookmarks_path(facility.id), method: :post , remote: true ,  id:"js-bookmark-button-for-facility-#{facility.id}", class:"icon-red" %>
-<%= facility.bookmarks.count %>
+<%= link_to facility_bookmarks_path(facility.id), method: :post , remote: true , id:"js-bookmark-button-for-facility-#{facility.id}", class:"favorite-icon" do %>
+  <%= icon('far', 'heart')  %>
+  &nbsp;
+  <%= facility.bookmarks.count %>
+<% end %>

--- a/app/views/facilities/bookmark.html.erb
+++ b/app/views/facilities/bookmark.html.erb
@@ -1,5 +1,3 @@
-<%= render "shared/breadcrumbs" %>
-
 <div class="list-body">
   <div class="list-title">
     <h3>お気に入り一覧</h3>

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -5,7 +5,7 @@
 <% end %>
 <div class="list-body row">
   <div class="list-title underline-blue">
-    <h3>おすすめ<%= type_text.to_s %></h3>
+    <h1>名護のおすすめ<%= type_text.to_s %></h1>
   </div>
   <div class="list-wrapper col-12">
     <div class="row " id="facility_lists">

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -1,4 +1,3 @@
-<%= render "shared/breadcrumbs" %>
 <% if @facility_type == "gourmet" %>
   <% type_text = "グルメ" %>
 <% else %>

--- a/app/views/facilities/index.html.erb
+++ b/app/views/facilities/index.html.erb
@@ -4,17 +4,17 @@
 <% else %>
   <% type_text = "観光スポット" %>
 <% end %>
-  <div class="list-body row">
-    <div class="list-title underline-blue">
-      <h3>おすすめ<%= type_text.to_s %></h3>
+<div class="list-body row">
+  <div class="list-title underline-blue">
+    <h3>おすすめ<%= type_text.to_s %></h3>
+  </div>
+  <div class="list-wrapper col-12">
+    <div class="row " id="facility_lists">
+      <%= render partial: 'facilities/facilities_list', collection: @facilities, as: 'facility' %>
     </div>
-    <div class="list-wrapper col-12">
-      <div class="row " id="facility_lists">
-        <%= render partial: 'facilities/facilities_list', collection: @facilities, as: 'facility' %>
-      </div>
-      <div class="list-button">
-        <%= link_to_next_page @facilities, "おすすめ#{type_text.to_s}をもっと見る", remote: true, class:"button button-blue-border" ,id:'view_more'%>
-      </div>
+    <div class="list-button">
+      <%= link_to_next_page @facilities, "おすすめ#{type_text.to_s}をもっとみる", remote: true, class:"button button-blue-border" ,id:'view_more'%>
     </div>
   </div>
+</div>
 <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_add_request: true } %>

--- a/app/views/fixedpages/about.html.erb
+++ b/app/views/fixedpages/about.html.erb
@@ -1,6 +1,4 @@
 <!-- マイページ-->
-<%= render "shared/breadcrumbs" %>
-
 <div class="list-body">
   <div class="list-title underline-blue">
     <h3>名護へGoについて</h3>

--- a/app/views/fixedpages/company.html.erb
+++ b/app/views/fixedpages/company.html.erb
@@ -1,5 +1,3 @@
-<%= render "shared/breadcrumbs" %>
-
 <div class="list-body">
   <div class="list-title underline-blue">
     <h3>運営会社情報</h3>

--- a/app/views/fixedpages/privacy.html.erb
+++ b/app/views/fixedpages/privacy.html.erb
@@ -1,6 +1,4 @@
 <!-- マイページ-->
-<%= render "shared/breadcrumbs" %>
-
 <div class="list-body">
   <div class="list-title underline-blue">
     <h3>プライバシーポリシー</h3>

--- a/app/views/fixedpages/tos.html.erb
+++ b/app/views/fixedpages/tos.html.erb
@@ -1,6 +1,4 @@
 <!-- マイページ-->
-<%= render "shared/breadcrumbs" %>
-
 <div class="list-body">
   <div class="list-title underline-blue">
     <h3>利用規約</h3>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,6 @@
 <div class="list-body row">
   <div class="list-title underline-blue">
-    <h3>おすすめグルメ</h3>
+    <h1>名護のおすすめグルメ</h1>
   </div>
   <div class="list-wrapper col-12">
     <div class="row">
@@ -13,7 +13,7 @@
 </div>
 <div class="list-body row bg-image-spot triangle-cut">
   <div class="list-title underline-white">
-    <h3 class="text-white">おすすめ観光スポット</h3>
+    <h1 class="text-white">名護のおすすめ観光スポット</h1>
   </div>
 
   <div class="list-wrapper col-12">

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -7,7 +7,7 @@
       <%= render partial: 'facilities/facilities_list', collection: @gourmets.first(FACILITY_NUM), as: 'facility' %>
     </div>
     <div class="list-button">
-      <%= link_to 'おすすめグルメをもっと見る', gourmets_list_path, class:"button button-blue-border button-arrow" %>
+      <%= link_to 'おすすめグルメをもっとみる', gourmets_list_path, class:"button button-blue-border button-arrow" %>
     </div>
   </div>
 </div>
@@ -21,7 +21,7 @@
       <%= render partial: 'facilities/facilities_list', collection: @spots.first(FACILITY_NUM), as: 'facility' %>
     </div>
     <div class="list-button">
-      <%= link_to '観光スポットをもっと見る', spots_list_path, class:"button button-white-border button-arrow" %>
+      <%= link_to '観光スポットをもっとみる', spots_list_path, class:"button button-white-border button-arrow" %>
     </div>
   </div>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<div class="list-body row">
+<section class="list-body row">
   <div class="list-title underline-blue">
     <h1>名護のおすすめグルメ</h1>
   </div>
@@ -10,8 +10,8 @@
       <%= link_to 'おすすめグルメをもっとみる', gourmets_list_path, class:"button button-blue-border button-arrow" %>
     </div>
   </div>
-</div>
-<div class="list-body row bg-image-spot triangle-cut">
+</section>
+<section class="list-body row bg-image-spot triangle-cut">
   <div class="list-title underline-white">
     <h1 class="text-white">名護のおすすめ観光スポット</h1>
   </div>
@@ -24,5 +24,5 @@
       <%= link_to '観光スポットをもっとみる', spots_list_path, class:"button button-white-border button-arrow" %>
     </div>
   </div>
-</div>
+</section>
 <%= render partial: "publics/bottom_area", locals: {sns_icon: true, facility_add_request: true } %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,6 +20,7 @@
     <div class="top-image"></div>
     <% end %>
     <div class="container-fluid" id="wrapper">
+      <%= render "shared/breadcrumbs" %>
       <%= yield %>
     </div>
     <%= render 'publics/footer'%>

--- a/app/views/menus/index.html.erb
+++ b/app/views/menus/index.html.erb
@@ -1,7 +1,4 @@
 <div class="menu-wrapper">
-  <div class="list-cd my-3">
-    <%= render "shared/breadcrumbs" %>
-  </div>
   <div class="detail-top mb-4">
     <%= image_tag(@facility.facility_images.first.image.url ,class:"card-img-top" ,alt:"...")  %>
     <h2 class="detail-title"><%= @facility.name%></h2>

--- a/app/views/publics/_bottom_area.html.erb
+++ b/app/views/publics/_bottom_area.html.erb
@@ -1,6 +1,7 @@
-  <div class="bottom">
+  <div class="bottom row">
     <% if local_assigns[:sns_icon] %>
-      <div class="bottom-sns-area">
+      <div class=" col-12">
+      <div class="sns-icons bottom-sns-area">
           <a href="#" class="sns-link">
             <%= image_tag('icon_twitter.svg', class:'sns-logo') %>
           </a>
@@ -11,14 +12,15 @@
             <%= image_tag('icon_insta.svg', class:'sns-logo') %>
           </a>
       </div>
+      </div>
     <% end %>
     <% if local_assigns[:facility_add_request] %>
-      <div class="bottom-text">
+      <div class="bottom-button col-12">
         <%= link_to "情報掲載依頼はこちら", new_inquiry_path(kind: 1), class:"button button-gradation" %>
       </div>
     <% end %>
     <% if local_assigns[:facility_edit_request] %>
-      <div class="bottom-text">
+      <div class="bottom-button col-12">
         <%= link_to "情報修正依頼はこちら", new_inquiry_path(kind: 2, facility_id: local_assigns[:facility_id]), class:"button button-gradation" %>
       </div>
     <% end %>

--- a/app/views/publics/_header.html.erb
+++ b/app/views/publics/_header.html.erb
@@ -1,63 +1,56 @@
-<nav class="navbar navbar-expand-md fixed-top header">
-  <div class="navbar-toggler header-icon-area" data-toggle="collapse" data-target=".navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
-    <div class="navbarTogglerDemo01 collapse show">
-      <%= image_tag('icon_menu.svg', class:'header-icon') %>
+<div class="fixed-top header">
+  <nav class="navbar navbar-expand-md">
+    <div class="navbar-toggler menu-icon-area" data-toggle="collapse" data-target=".navbarTogglerDemo01" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+      <div class="navbarTogglerDemo01 collapse show collapse-custom-animation">
+        <%= image_tag('icon_menu.svg', class:'header-icon') %>
+      </div>
+      <div class="navbarTogglerDemo01 collapse collapse-custom-animation">
+        <%= image_tag('icon_close.svg', class:'header-icon close-icon') %>
+      </div>
     </div>
-    <div class="navbarTogglerDemo01 collapse">
-      <%= image_tag('icon_close.svg', class:'header-icon close-icon') %>
+    <div class="logo-area">
+      <h1>
+        <%= link_to root_path do %>
+          <%= image_tag('logo.svg', class:'header-logo' ,alt:"名護へGO") %>
+        <% end %>
+      </h1>
     </div>
-  </div>
-  <div class="logo-area">
-    <%= link_to root_path do %>
-      <%= image_tag('logo.svg', class:'header-logo') %>
-    <% end %>
-  </div>
-  <div class="navbarTogglerDemo01 collapse header-icon-area">
-      <% if user_signed_in?	%>
-        <%= link_to user_path do %>
-          <%= image_tag('icon_account.svg', class:'header-icon') %>
+    <div class="account-icon-area">
+        <% if user_signed_in?	%>
+          <%= link_to user_path do %>
+            <%= image_tag('icon_account.svg', class:'header-icon') %>
+          <% end %>
+        <% else %>
+          <%= link_to new_user_session_path do %>
+            <%= image_tag('icon_login.svg', class:'header-icon') %>
+          <% end %>
         <% end %>
-      <% else %>
-        <%= link_to new_user_session_path do %>
-          <%= image_tag('icon_login.svg', class:'header-icon') %>
+    </div>
+    <div class="collapse navbar-collapse navbarTogglerDemo01">
+      <ul class="navbar-nav mt-2 mt-md-0">
+        <li class="nav-item-header">
+          <%= link_to 'グルメ', gourmets_list_path, class: "nav-link" %>
+        </li>
+        <li class="nav-item-header ">
+          <%= link_to '観光スポット', spots_list_path, class: "nav-link" %>
+        </li>
+        <% if user_signed_in?	%>
+          <li class="nav-item-header">
+            <%= link_to 'お気に入り', bookmarks_path, class: "nav-link" %>
+          </li>
+          <li class="nav-item-header">
+            <%= link_to '問合せ', new_inquiry_path(kind: 0), class: "nav-link" %>
+          </li>
+          <li class="nav-item-header">
+            <%= link_to 'ログアウト', destroy_user_session_path, class: "nav-link", method: :delete %>
+          </li>
+        <% else %>
+          <li class="nav-item-header">
+            <%= link_to '問合せ', new_inquiry_path(kind: 0), class: "nav-link" %>
+          </li>
         <% end %>
-      <% end %>
-  </div>
-  <div class="collapse navbar-collapse navbarTogglerDemo01">
-    <ul class="navbar-nav mt-2 mt-md-0">
-      <li class="nav-item-header">
-        <%= link_to 'グルメ', gourmets_list_path, class: "nav-link" %>
-      </li>
-      <li class="nav-item-header ">
-        <%= link_to '観光スポット', spots_list_path, class: "nav-link" %>
-      </li>
-      <% if user_signed_in?	%>
-        <li class="nav-item-header">
-          <%= link_to 'お気に入り', bookmarks_path, class: "nav-link" %>
-        </li>
-        <li class="nav-item-header">
-          <%= link_to '問合せ', new_inquiry_path(kind: 0), class: "nav-link" %>
-        </li>
-        <li class="nav-item-header">
-          <%= link_to 'ログアウト', destroy_user_session_path, class: "nav-link", method: :delete %>
-        </li>
-      <% else %>
-        <li class="nav-item-header">
-          <%= link_to '問合せ', new_inquiry_path(kind: 0), class: "nav-link" %>
-        </li>
-      <% end %>
-    </ul>
-  </div>
-  <div class="navbarTogglerDemo01 collapse show header-icon-area">
-      <% if user_signed_in?	%>
-        <%= link_to user_path do %>
-          <%= image_tag('icon_account.svg', class:'header-icon') %>
-        <% end %>
-      <% else %>
-        <%= link_to new_user_session_path do %>
-          <%= image_tag('icon_login.svg', class:'header-icon') %>
-        <% end %>
-      <% end %>
-  </div>
-</nav>
+      </ul>
+    </div>
+  </nav>
+</div>
 <div class="header-space-adjust"></div>

--- a/app/views/publics/_header.html.erb
+++ b/app/views/publics/_header.html.erb
@@ -9,11 +9,9 @@
       </div>
     </div>
     <div class="logo-area">
-      <h1>
         <%= link_to root_path do %>
           <%= image_tag('logo.svg', class:'header-logo' ,alt:"名護へGO") %>
         <% end %>
-      </h1>
     </div>
     <div class="account-icon-area">
         <% if user_signed_in?	%>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -1,27 +1,15 @@
+<%# コントローラー名とアクション名の組み合わせで表示させるパンくずリストを場合分け %>
 <% case params.values_at :controller, :action
   when ['users', 'show'] %>
     <% breadcrumb :mypage %>
   <% when ['facilities', 'bookmark'] %>
     <% breadcrumb :favorite %>
-  <% when ['facilities', 'show_facilities'] %>
-    <% if @facility_type == "gourmet" %>
-      <% type_text = "グルメ" %>
-    <% else %>
-      <% type_text = "観光スポット" %>
-    <% end %>
-    <% breadcrumb :facility_type, type_text %>
+  <% when ['facilities', 'index'] %>
+    <% breadcrumb :facility_index, @facility_type %>
   <% when ['facilities', 'show'] %>
-    <% if @facility.type == "gourmet" %>
-      <% breadcrumb :gourmet, @facility %>
-    <% else %>
-      <% breadcrumb :spot, @facility %>
-    <% end %>
+    <% breadcrumb :facility, @facility %>
   <% when ['menus', 'index'] %>
-    <% if @facility.type == "gourmet" %>
-      <% breadcrumb :gourmet, @facility %>
-    <% else %>
-      <% breadcrumb :spot, @facility %>
-    <% end %>
+    <% breadcrumb :menus, @facility %>
   <% when ['fixedpages', 'about'] %>
     <% breadcrumb :about %>
   <% when ['fixedpages', 'company'] %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,4 @@
 <!-- マイページ-->
-<%= render "shared/breadcrumbs" %>
-
 <div class="list-body">
   <!-- プロフィール -->
   <div class="user-top container">

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -2,26 +2,26 @@ crumb :root do
   link "home", root_path
 end
 
-crumb :gourmets do
-  link "グルメ", gourmets_list_path
+# 施設一覧
+crumb :facility_index do |facility_type|
+  if facility_type == "gourmet" 
+    link "グルメ", gourmets_list_path
+  else
+    link "観光スポット", spots_list_path
+  end
   parent :root
 end
-
-# グルメ個別ページのパンくずリスト
-crumb :gourmet do |facility|
-  link facility.name
-  parent :gourmets
+  
+# 施設個別ページ
+crumb :facility do |facility|
+  link facility.name, facility_path(facility)
+  parent :facility_index, facility.type
 end
 
-crumb :spots do
-  link "観光スポット", spots_list_path
-  parent :root
-end
-
-# 観光スポット個別ページのパンくずリスト
-crumb :spot do |facility|
-  link facility.name
-  parent :spots
+# メニュー一覧
+crumb :menus do |facility|
+  link 'メニュー'
+  parent :facility, facility
 end
 
 crumb :mypage do
@@ -31,11 +31,6 @@ end
 
 crumb :favorite do
   link "お気に入り（グルメ・観光スポット）"
-  parent :root
-end
-
-crumb :facility_type do |type_text|
-  link type_text.to_s
   parent :root
 end
 


### PR DESCRIPTION
## 目的
共通およびトップページのデザインを修正
詳細はIssue参照→(https://github.com/yoshitokamizato/go-to-nago/issues/249)

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->

### 共通
- フォントファミリーにGoogle fontの Noto Sans JPを適用
- パンくずリストの共通化とコードのリファクタリング
- PC表示時のヘッダーの固定幅を全幅に変更
- スマホのメニュークリック時に、アイコンが一瞬消える現象を解消
- メインロゴにalt設定をてきよう
- 各ページの見出しをH1タグに設定
- ボタンをセクション全幅まで拡張
- フッターの罫線が重複で引かれているのを調整

### トップ＆施設一覧
- マージン、文字サイズの調整
- お気に入りボタンのサイズ調整＆数字もリンク対象に設定


## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
TOP | 施設一覧
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/94880013-d03d0000-049c-11eb-9e2b-874e97137241.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/94880022-d501b400-049c-11eb-84f9-c5b46a91c11f.png" width="320"/>
