### PR TITLE
画面の調整（運営会社情報ページ) #215

### DIFF
--- a/app/assets/stylesheets/main/inquiries.scss
+++ b/app/assets/stylesheets/main/inquiries.scss
@@ -17,3 +17,9 @@
     margin: auto;
   }
 }
+
+.fixedpages-area{
+  max-width: 700px;
+  width: 70%;
+  margin: 3rem auto 3rem;
+}

--- a/app/views/fixedpages/about.html.erb
+++ b/app/views/fixedpages/about.html.erb
@@ -1,4 +1,4 @@
-<div class="list-body inquiry-area">
+<div class="list-body fixedpages-area">
   <div class="list-title underline-blue">
     <h1>名護へGoについて</h1>
   </div>

--- a/app/views/fixedpages/about.html.erb
+++ b/app/views/fixedpages/about.html.erb
@@ -1,7 +1,6 @@
-<!-- マイページ-->
-<div class="list-body">
+<div class="list-body inquiry-area">
   <div class="list-title underline-blue">
-    <h3>名護へGoについて</h3>
+    <h1>名護へGoについて</h1>
   </div>
 
   <div class="fixedpages-sentence">

--- a/app/views/fixedpages/company.html.erb
+++ b/app/views/fixedpages/company.html.erb
@@ -2,23 +2,24 @@
   <div class="list-title underline-blue">
     <h3>運営会社情報</h3>
   </div>
-
-  <table>
-    <tr>
-      <th>会社名</th>
-      <td>株式会社やんばるスパイク</td>
-    </tr>
-    <tr>
-      <th>創業</th>
-      <td>2019年</td>
-    </tr>
-    <tr>
-      <th>従業員数</th>
-      <td>100人</td>
-    </tr>
-    <tr>
-      <th>電話番号</th>
-      <td>000-000-0000</td>
-    </tr>
-  </table>
+  <div class="shop-information">
+    <ul class="information-lists">
+      <li class="information-list">
+        <p class="information-list-title">会社名</p>
+        <p class="information-list-content">株式会社やんばるスパイク</p>
+      </li>
+      <li class="information-list">
+        <p class="information-list-title">創業</p>
+        <p class="information-list-content">2019年</p>
+      </li>
+      <li class="information-list">
+        <p class="information-list-title">従業員数</p>
+        <p class="information-list-content">10名</p>
+      </li>
+      <li class="information-list">
+        <p class="information-list-title">電話番号</p>
+        <p class="information-list-content">000-000-0000</p>
+      </li>
+    </ul>
+  </div>
 </div>

--- a/app/views/fixedpages/company.html.erb
+++ b/app/views/fixedpages/company.html.erb
@@ -1,4 +1,4 @@
-<div class="list-body inquiry-area">
+<div class="list-body fixedpages-area">
   <div class="list-title underline-blue">
     <h1>運営会社情報</h1>
   </div>

--- a/app/views/fixedpages/company.html.erb
+++ b/app/views/fixedpages/company.html.erb
@@ -1,6 +1,6 @@
-<div class="list-body">
+<div class="list-body inquiry-area">
   <div class="list-title underline-blue">
-    <h3>運営会社情報</h3>
+    <h1>運営会社情報</h1>
   </div>
   <div class="shop-information">
     <ul class="information-lists">

--- a/app/views/fixedpages/privacy.html.erb
+++ b/app/views/fixedpages/privacy.html.erb
@@ -1,4 +1,4 @@
-<div class="list-body inquiry-area">
+<div class="list-body fixedpages-area">
   <div class="list-title underline-blue">
     <h1>プライバシーポリシー</h1>
   </div>

--- a/app/views/fixedpages/privacy.html.erb
+++ b/app/views/fixedpages/privacy.html.erb
@@ -1,7 +1,6 @@
-<!-- マイページ-->
-<div class="list-body">
+<div class="list-body inquiry-area">
   <div class="list-title underline-blue">
-    <h3>プライバシーポリシー</h3>
+    <h1>プライバシーポリシー</h1>
   </div>
 
   <div class="fixedpages-sentence">

--- a/app/views/fixedpages/tos.html.erb
+++ b/app/views/fixedpages/tos.html.erb
@@ -1,7 +1,6 @@
-<!-- マイページ-->
-<div class="list-body">
+<div class="list-body inquiry-area">
   <div class="list-title underline-blue">
-    <h3>利用規約</h3>
+    <h1>利用規約</h1>
   </div>
 
   <div class="fixedpages-sentence">

--- a/app/views/fixedpages/tos.html.erb
+++ b/app/views/fixedpages/tos.html.erb
@@ -1,4 +1,4 @@
-<div class="list-body inquiry-area">
+<div class="list-body fixedpages-area">
   <div class="list-title underline-blue">
     <h1>利用規約</h1>
   </div>
@@ -159,7 +159,8 @@
     </div>
     本規約の解釈にあたっては，日本法を準拠法とします。<br>
     本サービスに関して紛争が生じた場合には，当社の本店所在地を管轄する裁判所を専属的合意管轄とします。<br>
-  </div>
-
+    <br>
+    <br>
     <p class="text-right">以上</p>
+  </div>
 </div>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
「画面の調整（運営会社情報ページ) #215」の修正

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 運営会社情報ページのレイアウトを施設情報ページのレイアウトに合わせる。

## 影響範囲
運営会社情報ページ

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="" width="320"/> | <img src="" width="320"/>
![スクリーンショット 2020-10-06 22 04 32](https://user-images.githubusercontent.com/61322479/95206264-72ecda00-0821-11eb-9fa5-8b1088a3dcd3.png) | ![スクリーンショット 2020-10-06 22 09 32](https://user-images.githubusercontent.com/61322479/95206286-7a13e800-0821-11eb-8b6c-c71e2c9d0a30.png)

## その他
運営会社情報内容はかみざとさんに提示依頼中。
内容が提示され次第、運営会社情報の内容を更新する。