### PR TITLE
問い合わせ画面へのレイアウト適用

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,7 @@
 
 @import "font-awesome-sprockets";
 @import "font-awesome";
-@import "bootstrap/scss/bootstrap";
+// @import "bootstrap/scss/bootstrap";
 
 @import "common";
 @import "main/*";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,7 +14,7 @@
 
 @import "font-awesome-sprockets";
 @import "font-awesome";
-// @import "bootstrap/scss/bootstrap";
+@import "bootstrap/scss/bootstrap";
 
 @import "common";
 @import "main/*";

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -132,6 +132,28 @@ a:hover {
   }
 }
 
+.button-blue-color{
+  background-color: $main-color;
+  color: #fff;
+  border: 2px solid $main-color;
+  &:hover{
+    background-color: #fff;
+    color: $main-color;
+    border: 2px solid $main-color;
+  }
+}
+
+.button-gray-color{
+  background-color: $gray-color;
+  color: #fff;
+  border: 2px solid $gray-color;
+  &:hover{
+    background-color: #fff;
+    color: $gray-color;
+    border: 2px solid $gray-color;
+  }
+}
+
 .button-white-border{
   border: 2px solid #fff;
   color: #fff;
@@ -147,6 +169,13 @@ a:hover {
   background-image:-webkit-gradient(linear,left top,right bottom, from(#88B920), to(#55ACEE));
   &:hover{
     color: #fff;
+  }
+}
+
+.common-form {
+  .form-control{
+    border: 0.5px solid #000;
+    border-radius: 0;
   }
 }
 

--- a/app/assets/stylesheets/main/inquiries.scss
+++ b/app/assets/stylesheets/main/inquiries.scss
@@ -1,6 +1,6 @@
 .inquiry-area{
   max-width: 700px;
-  width: 70%;
+  width: 100%;
   margin: 3rem auto 3rem;
 }
 
@@ -11,9 +11,35 @@
   }
 }
 
-.inquiry-form{
-  .btn-area{
-    width: 70%;
-    margin: auto;
+// 問い合わせ情報
+.inquiry-information {
+  margin-top: 45px;
+  // wrapper
+  .information-lists {
+    // ul
+    .information-list {
+      // li
+      display: flex;
+      border-bottom: #888888 solid 1px;
+      padding: 10px 0;
+
+      p {
+        text-align: left;
+        margin-bottom: 0px;
+      }
+
+      .information-list-title {
+        // 各リストのカラム
+        width: 30%;
+        padding-left: 10px;
+        padding-right: 10px;
+        color: $main-color;
+        font-weight: bold;
+      }
+
+      .information-list-content {
+        width: 70%;
+      }
+    }
   }
 }

--- a/app/views/inquiries/confirm.html.erb
+++ b/app/views/inquiries/confirm.html.erb
@@ -50,8 +50,8 @@
       <%= f.hidden_field :kind %>
       <%= f.hidden_field :facility_id %>
     <div class="btn-area">
-      <%= f.submit '入力画面へ戻る', class: 'button button-gray-color', name: 'back' %>
       <%= f.submit '送信する', class: 'button button-blue-color' %>
+      <%= f.submit '入力画面へ戻る', class: 'button button-gray-color', name: 'back' %>
     </div>
 <% end %>
 </div>

--- a/app/views/inquiries/confirm.html.erb
+++ b/app/views/inquiries/confirm.html.erb
@@ -1,24 +1,47 @@
+<% 
+  case @inquiry.kind 
+  when "inquiry" 
+    inquiry_title = "お問い合わせ(確認)"
+    inquiry_sentece = "以下のお問い合わせ内容で送信します。よろしいですか？"
+  when "new_facility"
+    inquiry_title = "情報掲載依頼(確認)"
+    inquiry_sentece = "以下のお問い合わせ内容で送信します。よろしいですか？"
+  when "edit_facility"
+    inquiry_title = "情報修正依頼(確認)"
+    inquiry_sentece = "以下のお問い合わせ内容で送信します。よろしいですか？"
+  end
+ %>
+  
 <div class="inquiry-area">
   <div class="inquiry-title-area">
-    <% case @inquiry.kind %>
-    <% when "inquiry" %>
-      <h1>お問い合わせ(確認)</h1>
-      <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
-    <% when "new_facility" %>
-      <h1>情報掲載依頼(確認)</h1>
-      <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
-    <% when "edit_facility" %>
-      <h1>情報修正依頼(確認)</h1>
-      <p>以下のお問い合わせ内容で送信します。よろしいですか？</p>
-    <% end %>
+    <div class="inqury-title list-title underline-blue">
+      <h1><%= inquiry_title %></h1>
+    </div>
+      <p><%= inquiry_sentece %></p>
   </div>
+    <div class="inquiry-information">
+      <ul class="information-lists">
+        <li class="information-list">
+          <p class="information-list-title">お名前</p>
+          <p class="information-list-content"><%= @inquiry.name%></p>
+        </li>
+        <li class="information-list">
+          <p class="information-list-title">メールアドレス</p>
+          <p class="information-list-content"><%= @inquiry.email%></p>
+        </li>
+        <li class="information-list">
+          <p class="information-list-title">題名</p>
+          <p class="information-list-content"><%= @inquiry.subject%></p>
+        </li>
+        <li class="information-list">
+          <p class="information-list-title">お問い合わせ内容</p>
+          <div class="information-list-content"><%= simple_format(@inquiry.message) %></div>
+        </li>
+      </ul>
+    </div>
+    
+
   <%= form_for @inquiry ,action: '/create', html: {class: 'inquiry-form'} do |f| %>
-    <table class="table table-bordered">
-      <tr><th>お名前</th><td><%= @inquiry.name%></td></tr>
-      <tr><th>メールアドレス</th><td><%= @inquiry.email%></td></tr>
-      <tr><th>題名</th><td><%= @inquiry.subject%></td></tr>
-      <tr><th>お問い合わせ内容</th><td><%= simple_format(@inquiry.message) %></td></tr>
-    </table>
       <%= f.hidden_field :user_id %>
       <%= f.hidden_field :name %>
       <%= f.hidden_field :email %>
@@ -27,8 +50,8 @@
       <%= f.hidden_field :kind %>
       <%= f.hidden_field :facility_id %>
     <div class="btn-area">
-      <%= f.submit '入力画面へ戻る', class: 'btn btn-lg btn-secondary btn-block', name: 'back' %>
-      <%= f.submit '送信する', class: 'btn btn-lg btn-primary btn-block' %>
+      <%= f.submit '入力画面へ戻る', class: 'button button-gray-color', name: 'back' %>
+      <%= f.submit '送信する', class: 'button button-blue-color' %>
     </div>
 <% end %>
 </div>

--- a/app/views/inquiries/create.html.erb
+++ b/app/views/inquiries/create.html.erb
@@ -1,18 +1,28 @@
-<div class="inquiry-area">
+<% 
+  case @inquiry.kind 
+  when "inquiry" 
+    inquiry_title = "お問い合わせ(受付完了）"
+  when "new_facility"
+    inquiry_title = "情報掲載依頼(受付完了）"
+  when "edit_facility"
+    inquiry_title = "情報修正依頼(受付完了）"
+  end
+ %>
+ 
+ <div class="inquiry-area">
   <div class="inquiry-title-area">
-    <% case @inquiry.kind %>
-    <% when "inquiry" %>
-      <h1>お問い合わせ(受付完了）</h1>
-    <% when "new_facility" %>
-      <h1>情報掲載依頼(受付完了）</h1>
-    <% when "edit_facility" %>
-      <h1>情報修正依頼(受付完了）</h1>
-    <% end %>
+    <div class="inqury-title list-title underline-blue">
+      <h1><%= inquiry_title %></h1>
+    </div>
   </div>
 
-<p>問い合わせありがとうございます。</p>
-<p>お問い合わせ内容を、メールアドレスに送信いたしました。</p>
-<p>内容を確認して、回答させていただきます。</p>
-<p>なお、お問い合わせの内容によっては、回答にお時間をいただく場合がございます。</p>
+<div class="inquiry-information">
+<p>
+お問い合わせありがとうございます。<br /><br />
+お問い合わせ内容を、メールアドレスに送信いたしました。<br /><br />
+内容を確認して、回答させていただきます。<br />
+なお、お問い合わせの内容によっては、回答にお時間をいただく場合がございます。
+</p>
+</div>
 
 </div>

--- a/app/views/inquiries/new.html.erb
+++ b/app/views/inquiries/new.html.erb
@@ -1,29 +1,35 @@
+<% 
+  case @inquiry.kind 
+  when "inquiry" 
+    inquiry_title = "お問い合わせ(入力)"
+    inquiry_sentece = "ご意見・ご要望等、各種お問い合わせは、以下のフォームよりご連絡ください。"
+  when "new_facility"
+    inquiry_title = "情報掲載依頼(入力)"
+    inquiry_sentece = "「名護へGO」への情報掲載を希望される施設の情報を、以下のフォームよりご連絡ください。"
+  when "edit_facility"
+    inquiry_title = "情報修正依頼(入力)"
+    inquiry_sentece = "掲載情報に修正を希望される場合は、以下のフォームよりご連絡ください。"
+  end
+ %>
 
 <div class="inquiry-area">
-<div class="inquiry-title-area">
-  <% case @inquiry.kind %>
-  <% when "inquiry" %>
-    <h1>お問い合わせ(入力)</h1>
-    <p>ご意見・ご要望等、各種お問い合わせは、以下のフォームよりご連絡ください。</p>
-  <% when "new_facility" %>
-    <h1>情報掲載依頼(入力)</h1>
-    <p>「名護へGO」への情報掲載を希望される施設の情報を、以下のフォームよりご連絡ください。</p>
-  <% when "edit_facility" %>
-    <h1>情報修正依頼(入力)</h1>
-    <p>掲載情報に修正を希望される場合は、以下のフォームよりご連絡ください。</p>
-  <% end %>
-</div>
+  <div class="inquiry-title-area">
+    <div class="inqury-title list-title underline-blue">
+      <h1><%= inquiry_title %></h1>
+    </div>
+      <p><%= inquiry_sentece %></p>
+  </div>
 
-<%= form_for @inquiry, url: {action: "confirm"}, html: {class: 'inquiry-form'} do |f| %>
+<%= form_for @inquiry, url: {action: "confirm"}, html: {class: 'common-form inquiry-form'} do |f| %>
   <%= render 'shared/error_messages', object: f.object %>
 
   <div class="form-group">
-    <label for="inquiry_name">お名前<span class="badge badge-danger">必須</span></label>
+    <label for="inquiry_name">お名前 &nbsp;<span class="badge badge-danger">必須</span></label>
     <%= f.text_field :name, class: 'form-control', value: @inquiry.name, required: true  %>
   </div>
 
   <div class="form-group">
-    <label for="inquiry_email">メールアドレス<span class="badge badge-danger">必須</span></label>
+    <label for="inquiry_email">メールアドレス &nbsp;<span class="badge badge-danger">必須</span></label>
     <%= f.text_field :email, class: 'form-control', value: @inquiry.email, type: "email" , required: true %>
   </div>
 
@@ -33,7 +39,7 @@
   </div>
 
   <div class="form-group">
-    <label for="inquiry_message">お問い合わせ内容<span class="badge badge-danger">必須</span></label>
+    <label for="inquiry_message">お問い合わせ内容 &nbsp;<span class="badge badge-danger">必須</span></label>
     <%= f.text_area :message, size: '10x10', class: 'form-control', value: @inquiry.message, required: true %>
   </div>
 
@@ -41,7 +47,7 @@
   <%= f.hidden_field :kind, value: @inquiry.kind %>
   <%= f.hidden_field :facility_id, value: @inquiry.facility_id %>
   <div class="btn-area">
-    <%= f.submit '内容を確認する', class: 'btn btn-lg btn-primary btn-block' %>
+    <%= f.submit '内容を確認する', class: 'button button-blue-color' %>
   </div>
 
 <% end %>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
問い合わせ画面（入力、確認、受付完了）へデザインを適用する

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- フォーム、ボタンに対してデザインの適用 
- 問い合わせ種類の判定処理をリファクタリング - 

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
入力画面（スマホ） | 入力画面（PC）
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/95411304-24def000-0961-11eb-9d58-a4f36a185a0d.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/95411193-d29dcf00-0960-11eb-8a1b-754ee228b80f.png" width="400"/>

確認画面（スマホ） | 確認画面（PC）
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/95411311-28727700-0961-11eb-8cf5-0a9f361c2b0d.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/95411199-d92c4680-0960-11eb-8e66-f5a67370cb56.png" width="400"/>
受付完了画面（スマホ） | 受付完了画面（PC）

---- | ----
<img src="https://user-images.githubusercontent.com/36526480/95411317-2c05fe00-0961-11eb-8e79-c9918585ba6a.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/95411268-109af300-0961-11eb-91b5-b058560d8692.png" width="400"/>


