### PR TITLE
ログイン＆アカウント登録画面へのデザイン適用

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -172,6 +172,23 @@ a:hover {
   }
 }
 
+.button-twitter{
+  background-color: #00acee;
+  color: #fff;
+  position: relative;
+  &:before {
+    // position: absolute;
+    // left: 1vw;
+    margin-right: 1rem;
+    content: "\f099";
+    font-family: "Font Awesome 5 Brands";
+    font-weight: 400;
+  }
+  &:hover{
+    color: #fff;
+  }
+}
+
 .common-form {
   .form-control{
     border: 0.5px solid #000;

--- a/app/assets/stylesheets/main/users.scss
+++ b/app/assets/stylesheets/main/users.scss
@@ -1,5 +1,5 @@
 .login-area{
-  max-width: 700px;
+  max-width: 540px;
   width: 100%;
   margin: 3rem auto 3rem;
 }

--- a/app/assets/stylesheets/main/users.scss
+++ b/app/assets/stylesheets/main/users.scss
@@ -1,3 +1,13 @@
+.login-area{
+  max-width: 700px;
+  width: 100%;
+  margin: 3rem auto 3rem;
+}
+
+.with-virtical-spaces{
+  margin: 20px 0;
+}
+
 .user-image {
   width: 150px;
   height: 150px;

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,7 +1,8 @@
 <%= bootstrap_devise_error_messages!%>
-<div class="title">
-    <h4 class="text-center">メールアドレスを変更</h4>
-</div>
+  <div class="list-title underline-blue">
+    <h1><%= メールアドレスを変更 %></h1>
+  </div>
+
 <div class="container-login">
   <div class="mb-5">
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,14 +1,18 @@
-<div class="container-login">
-  <h2 class="text-center"><%= t('.sign_up') %></h2>
+<div class="login-area">
+  <div class="list-title underline-blue">
+    <h1><%= t('.sign_up') %></h1>
+  </div>
   <p class="text-center mt-3">SNSアカウントまたはメールアドレスで登録できます</p>
-  <div><%= link_to 'Twitterで登録', user_twitter_omniauth_authorize_path, class: "btn btn-primary btn-block mt-5" %></div>
+  <div><%= link_to 'Twitterで登録', user_twitter_omniauth_authorize_path, class: "button button-twitter mt-5 mb-2" %></div>
 
-  <p class="text-center">または</p>
+  <div class="with-virtical-spaces">
+    <p class="text-center">または</p>
+  </div>
 
-  <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: "common-form"}) do |f| %>
   <%= bootstrap_devise_error_messages!%>
   <div class="form-group">
-    <%= f.email_field :email, class:'form-control', autofocus: true, autocomplete: "email", placeholder: "メールアドレスを入力してください", value: @user.email, required: true %>
+    <%= f.email_field :email, class:'form-control', autocomplete: "email", placeholder: "メールアドレスを入力してください", value: @user.email, required: true %>
   </div>
 
   <div class="form-group">
@@ -20,12 +24,13 @@
   </div>
 
   <div class="form-group">
-    <%= f.submit "メールアドレスで登録", class:'btn btn-primary btn-block' %>
+    <%= f.submit "メールアドレスで登録", class:'button button-blue-color' %>
   </div>
   <% end %>
-  <p><a href="#">利用規約</a>、<a href="#">プライバシーポリシー</a>に同意の上でご登録ください</p>
+  
+  <p><%= link_to "利用規約", tos_path %>、<%= link_to "プライバシーポリシー", privacy_path %>に同意の上でご登録ください</p>
   <div class="border border-info p-3 mt-5">
     <p class="font-weight-bold pb-3">アカウントをお持ちの方はこちら</p>
-    <%= render "devise/shared/links" %>
+    <%= link_to "ログイン", new_session_path(resource_name), class: 'button button-blue-color' %>
   </div>
 </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,11 +1,20 @@
-<div class="container-login">
-  <h2><%= t('.sign_in')%></h2>
+<div class="login-area">
+  <div class="list-title underline-blue">
+    <h1><%= t('.sign_in') %></h1>
+  </div>
 
-  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+  <p class="text-center mt-3">SNSアカウントまたはメールアドレスでログインできます</p>
+  <div><%= link_to 'Twitterでログイン', user_twitter_omniauth_authorize_path, class: "button button-twitter mt-3" %></div>
+
+  <div class="with-virtical-spaces">
+    <p class="text-center">または</p>
+  </div>
+
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {class: "common-form"} ) do |f| %>
 
   <div class="form-group">
     <%= f.label :email %><br />
-    <%= f.email_field :email, class:'form-control', autofocus: true, autocomplete: "email" %>
+    <%= f.email_field :email, class:'form-control', autocomplete: "email" %>
   </div>
 
   <div class="form-group">
@@ -21,9 +30,19 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.submit "ログインする", class: 'btn btn-primary btn-block' %>
+    <%= f.submit "ログインする", class: 'button button-blue-color' %>
   </div>
   <% end %>
 
-  <%= render "devise/shared/links" %>
+  <div class="form-group">
+    <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'button button-gray-color' %><br />
+  </div>
+
+  <div class="border border-info p-3 mt-5">
+  <div class="form-group">
+    <p class="font-weight-bold pb-3">アカウントをお持ちでない方はこちら</p>
+    <%= link_to "アカウント登録", new_registration_path(resource_name), class: 'button button-blue-color' %>
+  </div>
+
+  </div>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,14 +1,20 @@
 <div class="form-group">
+  <%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+  <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: 'button button-twitter' %><br />
+  <% end -%>
+  <% end -%>
+
   <%- if controller_name != 'sessions' %>
-  <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'btn btn-info btn-block' %><br />
+  <%= link_to t(".sign_in"), new_session_path(resource_name), class: 'button button-blue-color' %><br />
   <% end -%>
 
   <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'btn btn-info btn-block' %><br />
+  <%= link_to t(".sign_up"), new_registration_path(resource_name), class: 'button button-blue-color' %><br />
   <% end -%>
 
   <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'btn btn-secondary btn-block' %><br />
+  <%= link_to t(".forgot_your_password"), new_password_path(resource_name), class: 'button button-gray-color' %><br />
   <% end -%>
 
   <%
@@ -23,9 +29,4 @@
   <%
 =end%>
 
-  <%- if devise_mapping.omniauthable? %>
-  <%- resource_class.omniauth_providers.each do |provider| %>
-  <%= link_to t('.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: 'btn btn-info btn-block' %><br />
-  <% end -%>
-  <% end -%>
 </div>

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -41,10 +41,11 @@ ja:
         update: "更新"
         we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
       new:
-        sign_up: "新規登録"
+        sign_up: "アカウント登録"
     sessions:
       new:
         sign_in: "ログイン"
+        forgot_your_password: "パスワードを忘れましたか?"
     shared:
       links:
         back: "戻る"


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
ログイン＆アカウン登録画面にデザインを適用

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 共通のボタンデザインを適用（twitterボタンは新規デザイン作成）
- 共通のフォームデザインを適用
- ログイン＆アカウン登録で、ボタン順序の統一化（twitter → email認証の順）
- 余白の調整

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->

- アカウント登録画面

スマホ | PC
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/96090087-aeaf3000-0f02-11eb-9cc3-59be90bb0d1e.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/96090092-b1118a00-0f02-11eb-9dce-d48e796d2a92.png" width="400"/>

- ログイン画面

スマホ | PC
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/96090370-11a0c700-0f03-11eb-8f72-f35b33eaea8a.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/96090355-0e0d4000-0f03-11eb-8418-a5fc8d690622.png" width="400"/>
