### PR TITLE
ロゴ画像の高さ調整＆h1タグの文字サイズ変更

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -270,11 +270,16 @@ nav.navbar{
   position: relative;
   // height: 100%;
   max-width: 70%;
+  a {
+    display: flex;
+    height: 100%;
+    align-items: center;
+  }  
 }
 
 .header-logo{
   object-fit: contain;
-  height: 100%;
+  height: 85%;
   width: auto;
   max-width: 100%;
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -33,7 +33,7 @@ a:hover {
   text-align: center;
   h1{
    font-weight: bold;
-   font-size: 1.2rem;
+   font-size: 1.4rem;
  }
 }
 


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
ロゴ画像の高さ調整＆h1タグの文字サイズ変更

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- ロゴ画像の上下に余白を作るため100%→85%変更
- スマホ表示時のh1タグの文字サイズを1.2remから1.4remへ変更 

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->

- スマホ

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/97137952-6ad9e780-179a-11eb-8ad5-297ae1843184.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/97137965-71685f00-179a-11eb-81cb-181da4feb4c8.png" width="320"/>

- PC

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/97137960-6f060500-179a-11eb-82ed-ebfa10adc993.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/97137964-70cfc880-179a-11eb-95f4-07beb9ace0df.png" width="320"/>
