### PR TITLE
もっと見るボタンのエラー（スポットページでグルメが表示される）の修正

### DIFF
--- a/app/controllers/facilities_controller.rb
+++ b/app/controllers/facilities_controller.rb
@@ -5,14 +5,16 @@ class FacilitiesController < ApplicationController
   end
 
   # 一覧表示
-  def index
-    if request.fullpath.include?("gourmet") == true
-      @facility_type = "gourmet"
-    else
-      @facility_type = "spot"
-    end
-
+  def spots_index
+    @facility_type = "spot"
     @facilities = Facility.includes(:facility_images).where(type: @facility_type).page(params[:page])
+    render :index
+  end
+
+  def gourmets_index
+    @facility_type = "gourmet"
+    @facilities = Facility.includes(:facility_images).where(type: @facility_type).page(params[:page])
+    render :index
   end
 
 

--- a/app/views/facilities/index.js.erb
+++ b/app/views/facilities/index.js.erb
@@ -1,6 +1,6 @@
 $('#facility_lists').append("<%= escape_javascript(render partial: 'facilities/facilities_list',  collection: @facilities, as: 'facility') %>");
 <% if @facility_type == "gourmet" %>
-$("#view_more").replaceWith("<%= escape_javascript(link_to_next_page(@facilities, 'おすすめグルメをもっと見る', remote: true, class:"button button-blue-border" ,id:'view_more')) %>");
+$("#view_more").replaceWith("<%= escape_javascript(link_to_next_page(@facilities, 'おすすめグルメをもっとみる', remote: true, class:"button button-blue-border" ,id:'view_more')) %>");
 <% else %>
-$("#view_more").replaceWith("<%= escape_javascript(link_to_next_page(@facilities, '観光スポットをもっと見る', remote: true, class:"button button-white-border" ,id:'view_more')) %>");
+$("#view_more").replaceWith("<%= escape_javascript(link_to_next_page(@facilities, 'おすすめ観光スポットをもっとみる', remote: true, class:"button button-blue-border" ,id:'view_more')) %>");
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,8 @@ Rails.application.routes.draw do
   get "/tos", to: "fixedpages#tos"
   get "/gourmet/:id", to: "facilities#show", as: "gourmet"
   get "/spot/:id", to: "facilities#show", as: "spot"
-  get "/gourmets/list", to: "facilities#index"
-  get "/spots/list", to: "facilities#index"
+  get "/gourmets/list", to: "facilities#gourmets_index"
+  get "/spots/list", to: "facilities#spots_index"
   get "/gourmet/:facility_id/menus", to: "menus#index", as: "gourmet_menus"
   get "/spot/:facility_id/menus", to: "menus#index", as: "spot_menus"
 


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
(#265 )観光スポット一覧の「もっとみる」ボタンを押すと、グルメ情報が表示される。 の改修

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- グルメ一覧、観光スポット一覧でcontoroller内のアクションを分割


## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
※修正前は、観光スポット一覧で「もっと見るボタン」を押すとグルメ情報が表示され、
 「もっと見るボタン」もグルメに置き換わっている


before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/97456296-12fad680-197c-11eb-8f38-14d02544bf2e.png" width="320"/> |<img src="https://user-images.githubusercontent.com/36526480/97456280-0e362280-197c-11eb-95e9-a8b77c0855fe.png" width="320"/>  

## 参考：エラーの原因と修正方法
【原因】
もっと見るボタンはkaminari gemの`link_to_next_page`メソッドを使ってリンク先URLを生成していますが、処理を追っていくと、#<ActionDispatch::Routing::RouteSet>のgenerateメソッド内で、{:controller=>"facilities", :action=>"index", :page=>"2"}を引数に、routes情報からマッチをかけて、一番上に該当したurlをpathに設定しています。
現状routeファイルで設定した「グルメ一覧(/gourmets/list)」「スポット一覧(/spots/list)」はいずれも、:controller=>"facilities", :action=>"index" でありますが、上記のurl generateの際には、常に「グルメ一覧(/gourmets/list)」がヒットし、もっと見るのリンク先が常に/gourmets/listとなるため

【対応方針】
以下の①の方針で対応した
①グルメ一覧とスポット一覧で、コントローラ内のアクション名を分ける
（ただし重複した処理を、複数存在させることになるので、すべきではないのかもしれませんが・・）
②グルメ一覧とスポット一覧のURLのパラメータに施設タイプを含める(ex. /facilities?type="spot")
※以前、URLを整理する前にはこの方式でもっと見るボタンがうまく動いていたため。
