### PR TITLE
プロフィール登録/編集時のプロフ画像の各種改善

### DIFF
--- a/app/assets/stylesheets/main/users.scss
+++ b/app/assets/stylesheets/main/users.scss
@@ -8,6 +8,22 @@
   margin: 20px 0;
 }
 
+#user-img-field {
+  position: relative;
+  cursor: pointer;
+  width: 200px;
+  height: 160px;
+}
+
+#user-img-field i{
+  // display: none;
+  font-size: 40px;
+  position: absolute;
+  top: 110px;
+  right: 20px;
+  color: $main-color;
+}
+
 .user-image {
   width: 150px;
   height: 150px;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,6 +21,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     # 引数のresourceを使ってユーザーを取得
     # メール認証から来た時と戻るボタンから来た時で場合わけ(paramsが違うため)
     # 確認メールから編集画面に来た時
+    # binding.pry
     if params["resource"]
       @user = User.find(params["resource"])
       # 初回登録か、既に会員登録済みかを場合わけ
@@ -39,7 +40,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user.prefecture = params["user"]["prefecture"]
       @user.sex = params["user"]["sex"]
       @user.birth_year = params["user"]["birth_year"]
-      @user.image = params["user"]["image"]
+      @user.image = params["user"]["image_cache"]
+      # @user.image = params["user"]["image"]
       @user.profile = params["user"]["profile"]
       @user.mailmagazine = params["user"]["mailmagazine"]
       @token = params["user"]["confirmation_token"]
@@ -61,6 +63,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user.sex = params["user"]["sex"]
       @user.birth_year = params["user"]["birth_year"]
       @user.image = params["user"]["image"]
+      # 選択していない場合でも、キャッシュから復活させる（確認画面から戻る場合を想定）
+      if !@user.image.present?
+        @user.image.retrieve_from_cache! params["user"]["image_cache"]
+      end
+      @user.image_cache = @user.image.cache_name
       @user.profile = params["user"]["profile"]
       @user.mailmagazine = params["user"]["mailmagazine"]
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,7 +21,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
     # 引数のresourceを使ってユーザーを取得
     # メール認証から来た時と戻るボタンから来た時で場合わけ(paramsが違うため)
     # 確認メールから編集画面に来た時
-    # binding.pry
     if params["resource"]
       @user = User.find(params["resource"])
       # 初回登録か、既に会員登録済みかを場合わけ
@@ -41,7 +40,6 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user.sex = params["user"]["sex"]
       @user.birth_year = params["user"]["birth_year"]
       @user.image = params["user"]["image_cache"]
-      # @user.image = params["user"]["image"]
       @user.profile = params["user"]["profile"]
       @user.mailmagazine = params["user"]["mailmagazine"]
       @token = params["user"]["confirmation_token"]
@@ -64,10 +62,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user.birth_year = params["user"]["birth_year"]
       @user.image = params["user"]["image"]
       # 選択していない場合でも、キャッシュから復活させる（確認画面から戻る場合を想定）
-      if !@user.image.present?
+      if !@user.image.present? && params["user"]["image_cache"].present?
         @user.image.retrieve_from_cache! params["user"]["image_cache"]
       end
-      @user.image_cache = @user.image.cache_name
       @user.profile = params["user"]["profile"]
       @user.mailmagazine = params["user"]["mailmagazine"]
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -19,3 +19,4 @@ require("jquery");
 // const imagePath = (name) => images(name, true)
 import "bootstrap";
 import "../stylesheets/application";
+import "../user/mypage.js";

--- a/app/javascript/user/mypage.js
+++ b/app/javascript/user/mypage.js
@@ -4,7 +4,7 @@ $('#user-tag-icon').mouseover(function() {
 
 });
 
-$(function() {
+$(document).on('turbolinks:load', function() {
   function readURL(input) {
     if (input.files && input.files[0]) {
       var reader = new FileReader();
@@ -14,7 +14,7 @@ $(function() {
       reader.readAsDataURL(input.files[0]);
     }
   }
-  $("#user-imag-file").on('change', function(){
+  $("#user-img-file").on('change', function(){
       readURL(this);
   });
 });

--- a/app/javascript/user/mypage.js
+++ b/app/javascript/user/mypage.js
@@ -3,3 +3,18 @@ $('#user-tag-icon').mouseover(function() {
   console.log('マウスオーバーしました！');
 
 });
+
+$(function() {
+  function readURL(input) {
+    if (input.files && input.files[0]) {
+      var reader = new FileReader();
+      reader.onload = function (e) {
+        $('#img-preview').attr('src', e.target.result);
+      }
+      reader.readAsDataURL(input.files[0]);
+    }
+  }
+  $("#user-imag-file").on('change', function(){
+      readURL(this);
+  });
+});

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,7 +28,15 @@
 
   <div class="form-group">
     <%= f.label :image %> <br />
-    <%= f.file_field :image, class: "aform-control", accept: "image/jpg,image/gif,image/jpeg,image/png", autofocus: true %>
+    <div id="user-img-field" onClick="$('#user-img-file').click()" >
+      <% if @user.image.url %>
+        <%= image_tag @user.image.url ,class:"user-image" ,id:"img-preview" %>
+      <% else %>
+        <%= image_tag "no-image.png" ,class:"non-user-image" ,id:"img-preview"  %>
+      <% end %>
+      <i class="fas fa-edit"></i>
+    </div>
+    <%= f.file_field :image, value: @user.image, accept: "image/jpg,image/gif,image/jpeg,image/png", style: "display:none;", id: "user-img-file" %>
   </div>
 
   <div class="form-group">

--- a/app/views/devise/registrations/regist.html.erb
+++ b/app/views/devise/registrations/regist.html.erb
@@ -28,9 +28,14 @@
     <%= f.select :birth_year, @birth_year, {include_blank: "生まれた年を選択してください"}, class: "form-control" %>
   </div>
 
+<%# binding.pry %>
+
   <div class="form-group">
     <%= f.label :image %> <br />
-    <%= f.file_field :image, accept: "image/jpg,image/gif,image/jpeg,image/png" %>
+    <% if @user.image.url %>
+    <%= image_tag @user.image.url ,class:"user-image"%>
+    <% end %>
+    <%= f.file_field :image, value: @user.image, accept: "image/jpg,image/gif,image/jpeg,image/png" %>
     <%= f.hidden_field :image_cache %>
   </div>
 

--- a/app/views/devise/registrations/regist.html.erb
+++ b/app/views/devise/registrations/regist.html.erb
@@ -30,7 +30,7 @@
 
   <div class="form-group">
     <%= f.label :image %> <br />
-    <div id="user-img-field" onClick="$('#user-imag-file').click()" >
+    <div id="user-img-field" onClick="$('#user-img-file').click()" >
       <% if @user.image.url %>
         <%= image_tag @user.image.url ,class:"user-image" ,id:"img-preview" %>
       <% else %>
@@ -38,7 +38,7 @@
       <% end %>
       <i class="fas fa-edit"></i>
     </div>
-    <%= f.file_field :image, value: @user.image, accept: "image/jpg,image/gif,image/jpeg,image/png", style: "display:none;", id: "user-imag-file" %>
+    <%= f.file_field :image, value: @user.image, accept: "image/jpg,image/gif,image/jpeg,image/png", style: "display:none;", id: "user-img-file" %>
     <%= f.hidden_field :image_cache %>
   </div>
 

--- a/app/views/devise/registrations/regist.html.erb
+++ b/app/views/devise/registrations/regist.html.erb
@@ -28,14 +28,17 @@
     <%= f.select :birth_year, @birth_year, {include_blank: "生まれた年を選択してください"}, class: "form-control" %>
   </div>
 
-<%# binding.pry %>
-
   <div class="form-group">
     <%= f.label :image %> <br />
-    <% if @user.image.url %>
-    <%= image_tag @user.image.url ,class:"user-image"%>
-    <% end %>
-    <%= f.file_field :image, value: @user.image, accept: "image/jpg,image/gif,image/jpeg,image/png" %>
+    <div id="user-img-field" onClick="$('#user-imag-file').click()" >
+      <% if @user.image.url %>
+        <%= image_tag @user.image.url ,class:"user-image" ,id:"img-preview" %>
+      <% else %>
+        <%= image_tag "no-image.png" ,class:"non-user-image" ,id:"img-preview"  %>
+      <% end %>
+      <i class="fas fa-edit"></i>
+    </div>
+    <%= f.file_field :image, value: @user.image, accept: "image/jpg,image/gif,image/jpeg,image/png", style: "display:none;", id: "user-imag-file" %>
     <%= f.hidden_field :image_cache %>
   </div>
 


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
プロフィール画像登録に関して以下の改善を実施する。
- プロフィール登録時の確認画面から入力画面へ戻ると、プロフ画像の選択が消えるため、維持するようにする。
- プロフィール編集画面で現在のプロフ画像が表示されないため、表示できるようにする。
- プロフ画像選択時にはプレビュー表示できるようにする。

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 確認画面→入力画面の遷移時に、image_cacheに保存されたデータからimage fileを復元する。
- 画像入力エリアを通常のfile_fileldから、画像＋アイコンに変更(html + css)
- 画像選択を契機に、表示している画像ファイルを選択した画像に入れ替える（jqueryで実装）

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->

### プロフィール登録画面

入力画面（未入力） | 入力画面（画像選択後） | 確認画面 | 入力画面（確認画面から戻った場合） |
---- | ---- | ---- | ----
<img src="https://user-images.githubusercontent.com/36526480/98810938-5452b200-2463-11eb-8e01-f2407a757d52.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/98810934-53ba1b80-2463-11eb-93f1-c0b598ccfad5.png" width="200"/>| <img src="https://user-images.githubusercontent.com/36526480/98810932-53218500-2463-11eb-9824-17a66529148c.png" width="200"/>| <img src="https://user-images.githubusercontent.com/36526480/98810929-50bf2b00-2463-11eb-824f-54b0c08ac168.png" width="200"/>

### プロフィール編集画面

編集画面（未編集） | 編集画面（画像変更後） | プロフィール画面（編集後）<br /> ※レイアウトは別プルリク対応中 
---- | ---- | ---- 
<img src="https://user-images.githubusercontent.com/36526480/98817755-f37ca700-246d-11eb-8b35-7c2f6eb22b1e.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/98817753-f24b7a00-246d-11eb-892d-48d52d9c0e56.png" width="200"/> | <img src="https://user-images.githubusercontent.com/36526480/98817745-f081b680-246d-11eb-909c-d9e2157be4c8.png" width="200"/> 

