### PR TITLE
Twitter認証を使用した会員登録処理の変更

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,20 +11,11 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   
     # common callback method
     def callback_for(provider)
-      # @user.skip_confirmation!
       @user = User.from_omniauth(request.env["omniauth.auth"])
-      unless @user.persisted?
-        @user.skip_confirmation!
-        @user.save!
-      end
       if @user.active?
         sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
         set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
       else
-        # @user.skip_confirmation!
-        # @user.save!
-        # session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
-        # redirect_to new_user_registration_url(user: @user)
         redirect_to before_sign_up_path(provider: provider, 
                                         uid: @user.uid)
       end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,13 +11,23 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   
     # common callback method
     def callback_for(provider)
+      binding.pry
+      # @user.skip_confirmation!
       @user = User.from_omniauth(request.env["omniauth.auth"])
-      if @user.persisted?
+      unless @user.persisted?
+        @user.skip_confirmation!
+        @user.save!
+      end
+      if @user.active?
         sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
         set_flash_message(:notice, :success, kind: "#{provider}".capitalize) if is_navigational_format?
       else
-        session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
-        redirect_to new_user_registration_url
+        # @user.skip_confirmation!
+        # @user.save!
+        # session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
+        # redirect_to new_user_registration_url(user: @user)
+        redirect_to before_sign_up_path(provider: provider, 
+                                        user: {user_id: @user})
       end
     end
   
@@ -48,4 +58,5 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # def after_omniauth_failure_path_for(scope)
   #   super(scope)
   # end
+
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -11,7 +11,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   
     # common callback method
     def callback_for(provider)
-      binding.pry
       # @user.skip_confirmation!
       @user = User.from_omniauth(request.env["omniauth.auth"])
       unless @user.persisted?
@@ -27,7 +26,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         # session["devise.#{provider}_data"] = request.env["omniauth.auth"].except("extra")
         # redirect_to new_user_registration_url(user: @user)
         redirect_to before_sign_up_path(provider: provider, 
-                                        user: {user_id: @user})
+                                        uid: @user.uid)
       end
     end
   

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -18,6 +18,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # 仮登録時にプロフィールを編集するアクション
   def regist
+    # binding.pry
     # 引数のresourceを使ってユーザーを取得
     # メール認証から来た時と戻るボタンから来た時で場合わけ(paramsが違うため)
     # 確認メールから編集画面に来た時
@@ -43,6 +44,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
       @user.profile = params["user"]["profile"]
       @user.mailmagazine = params["user"]["mailmagazine"]
       @token = params["user"]["confirmation_token"]
+      @user.email = params["user"]["email"]
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,9 +36,15 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: %i[twitter]
   # omniauthのコールバック時に呼ばれるメソッド
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = auth.info.email
+    where(provider: auth.provider, uid: auth.uid).first_or_initialize do |user|
+      user.email = auth.info.email || User.dummy_email(auth)
       user.password = Devise.friendly_token[0,20]
     end
   end
+
+  private
+
+    def self.dummy_email(auth)
+      "#{auth.uid}-#{auth.provider}@example.com"
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,14 +37,18 @@ class User < ApplicationRecord
   # omniauthのコールバック時に呼ばれるメソッド
   def self.from_omniauth(auth)
     where(provider: auth.provider, uid: auth.uid).first_or_initialize do |user|
-      user.email = auth.info.email || User.dummy_email(auth)
+      user.email = auth.info.email || User.set_dummy_email(auth.uid, auth.provider)
       user.password = Devise.friendly_token[0,20]
     end
   end
 
+  def has_dummy_email?
+    self.email == User.set_dummy_email(self.uid, self.provider)
+  end
+
   private
 
-    def self.dummy_email(auth)
-      "#{auth.uid}-#{auth.provider}@example.com"
+    def self.set_dummy_email(uid, provider)
+      "#{uid}-#{provider}@example.com"
     end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,9 +36,10 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: %i[twitter]
   # omniauthのコールバック時に呼ばれるメソッド
   def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_initialize do |user|
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
       user.email = auth.info.email || User.set_dummy_email(auth.uid, auth.provider)
       user.password = Devise.friendly_token[0,20]
+      user.skip_confirmation!
     end
   end
 

--- a/app/views/devise/registrations/confirm.html.erb
+++ b/app/views/devise/registrations/confirm.html.erb
@@ -19,6 +19,12 @@
 
     <div class="inquiry-information">
       <ul class="information-lists">
+        <% if @user.provider.present? %>
+        <li class="information-list">
+          <%= f.label :email ,class:"information-list-title" %>
+          <p class="information-list-content"><%= @user.email %></p>
+        </li>
+        <% end %>
         <li class="information-list">
           <%= f.label :nickname ,class:"information-list-title" %>
           <p class="information-list-content"><%= @user.nickname %></p>

--- a/app/views/devise/registrations/regist.html.erb
+++ b/app/views/devise/registrations/regist.html.erb
@@ -5,8 +5,15 @@
   <p class="text-center mt-3">プロフィールを登録してください。</p>
   <%= form_for(@user, as: @user, url: before_sign_up_confirm_path(@user, confirmation_token: @token) ,html: {method: "post", class: "common-form"}) do |f| %>
   <%= bootstrap_devise_error_messages!%>
-  <%= render "devise/shared/error_messages", resource: @user %>
+  <%#= render "devise/shared/error_messages", resource: @user %>
   <%= f.hidden_field :user_id, :value =>  resource.id %>
+
+  <% if @user.provider.present? %>
+  <div class="form-group">
+    <%= f.label :email %><span class="badge badge-danger ml-2">必須</span>
+    <%= f.text_field :email, class:'form-control', autofocus: true, autocomplete: "nickname", placeholder: "Emailを入力してください", required: true %>
+  </div>
+  <% end %>
 
   <div class="form-group">
     <%= f.label :nickname %><span class="badge badge-danger ml-2">必須</span>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
Twitterアカウントを使用した会員登録について、処理の流れを変更する
具体的には以下のTwitter認証後の、本人確認メール送信は不要（Twitter側で認証できているため）で、直接プロフィール登録画面へ遷移させる

・現状のTwitter認証を使用した会員登録の流れ
Twitterで会員登録(名護へGO)→認証(Twitter)→本人確認メール送信(名護へGO)→プロフィール登録(名護へGO)

また、 Twitterでメールアドレスが未登録の場合も鑑みて、メールアドレスが取得できなかった場合は
プロフィール登録画面で登録させる処理に変更する。


## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
Twitter認証を使用した、会員登録で以下を実装させる
- [x] メールアドレスを取得できなくても、仮登録する
  → Twitterからメールアドレスを取得できなかった場合は、ダミーアドレスを仮登録(`user.rb`)
- [x] 仮登録した際に確認メールを送信しない
  → Twitter認証でUserオブジェクト作成時は、deviseのconfirmation機能をskip(`user.rb`)
- [x] 仮登録後にプロフィール画面へ自動遷移
  → Twitter認証でUserレコードがacitiveではないときは、プロフィール登録画面へ遷移(`omniauth_callbacks_controller.rb`)
- [x] プロフィール画面でメールアドレスを登録
  → Twitter認証の場合、メールアドレス入力欄を表示＆登録。
       またダミーアドレスの場合は、入力フォームから削除して 入力させる(`registrations_controller.rb`,`regist.html.erb`,`confirm.html.erb`)

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
流れ | メールアドレスで会員登録 | Twitterで会員登録
---- | ---- | ----
新規登録画面 |<img src="https://user-images.githubusercontent.com/36526480/100256576-4c792e80-2f88-11eb-8312-7fcfd3212fbc.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/100259313-6b2cf480-2f8b-11eb-9660-a0534f2812fa.png" width="320"/>
メールorTwitter画面 |<img src="https://user-images.githubusercontent.com/36526480/100256571-4be09800-2f88-11eb-8995-7d6692410ca0.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/100259312-6b2cf480-2f8b-11eb-9d0a-6e01b1b409af.png" width="320"/>
プロフィール入力 | <img src="https://user-images.githubusercontent.com/36526480/100256567-4b480180-2f88-11eb-90e6-cfb89300e3a2.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/100259311-69fbc780-2f8b-11eb-8753-ce91c446354f.png" width="320"/>
プロフィール確認 | <img src="https://user-images.githubusercontent.com/36526480/100256565-4aaf6b00-2f88-11eb-80d3-b0b9dcb469ec.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/100259304-69633100-2f8b-11eb-96bd-b0a0f9cd279e.png" width="320"/>
プロフィール登録完了 | <img src="https://user-images.githubusercontent.com/36526480/100256552-471be400-2f88-11eb-97e3-dbef43b9e82e.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/100259290-66684080-2f8b-11eb-8b65-68d7469f4902.png" width="320"/>
