### PR TITLE
施設ページのURLがリンクになっていない #296

### DIFF
--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -122,7 +122,7 @@
         </li>
         <li class="information-list">
           <p class="information-list-title">URL</p>
-          <p class="information-list-content"><%= @facility.home_page %></p>
+          <p class="information-list-content"><%= link_to(@facility.home_page, @facility.home_page, target: :_blank) %></p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## 目的
「施設ページのURLがリンクになっていない #296」の修正

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 施設ページのURLのリンクを設定(別タブでオープン)

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/61322479/101481935-424c2c80-3999-11eb-87e0-f55eb6579522.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/101481989-555efc80-3999-11eb-8bc8-dad15ba5c6be.png" width="320"/>