### PR TITLE
管理画面の絞込項目の修正 #297

### DIFF
--- a/app/admin/admin_users.rb
+++ b/app/admin/admin_users.rb
@@ -5,15 +5,11 @@ ActiveAdmin.register AdminUser do
     selectable_column
     id_column
     column :email
-    column :current_sign_in_at
-    column :sign_in_count
     column :created_at
     actions
   end
 
   filter :email
-  filter :current_sign_in_at
-  filter :sign_in_count
   filter :created_at
 
   form do |f|

--- a/app/admin/facilities.rb
+++ b/app/admin/facilities.rb
@@ -112,4 +112,29 @@ ActiveAdmin.register Facility do
       li link_to 'メニュー 一覧',   admin_facility_menus_path(resource)
     end
   end
+
+  # 絞り込み条件の項目設定
+  filter :type
+  filter :name
+  filter :postal_code
+  filter :address
+  filter :latitude
+  filter :longitude
+  filter :running_time
+  filter :tel
+  filter :email
+  filter :budget
+  filter :description
+  filter :advice
+  filter :holiday
+  filter :parking
+  filter :home_page
+  filter :owner_id
+  filter :instagram
+  filter :twitter
+  filter :youtube
+  filter :status
+  filter :created_user
+  filter :updated_user
+  filter :opening_hours
 end

--- a/app/admin/facilities.rb
+++ b/app/admin/facilities.rb
@@ -42,32 +42,36 @@ ActiveAdmin.register Facility do
     column :name
     column :postal_code
     column :address
-    column :latitude
-    column :longitude
-    column :running_time
+#    column :latitude
+#    column :longitude
+#    column :running_time
     column :tel
     column :email
-    column :budget
-    column :description
-    column :advice
+#    column :budget
+#    column :description
+#    column :advice
     column :holiday
     column :parking
-    column :home_page
-    column :owner_id
-    column :instagram
-    column :twitter
-    column :youtube
+#    column :home_page
+#    column :owner_id
+#    column :instagram
+#    column :twitter
+#    column :youtube
     column(:status) do |facility|
       facility.status_i18n
     end
-    column :created_user
-    column :updated_user
+#    column :created_user
+#    column :updated_user
     column :opening_hours
-    column 'facility_images' do |facility|
-      link_to '施設画像一覧', admin_facility_facility_images_path(facility.id)
+    column :facility_images do |facility|
+      div(class: "facility-link-width") do
+        link_to '施設画像一覧', admin_facility_facility_images_path(facility.id)
+      end
     end
-    column 'menu' do |facility|
-      link_to 'メニュー 一覧',   admin_facility_menus_path(facility.id)
+    column :menu do |facility|
+      div(class: "facility-link-width") do
+        link_to 'メニュー 一覧',   admin_facility_menus_path(facility.id)
+      end
     end
     actions # 後述するpermit_paramsの設定に応じて閲覧編集削除などのリンクを表示
   end
@@ -118,23 +122,23 @@ ActiveAdmin.register Facility do
   filter :name
   filter :postal_code
   filter :address
-  filter :latitude
-  filter :longitude
-  filter :running_time
+#  filter :latitude
+#  filter :longitude
+#  filter :running_time
   filter :tel
   filter :email
-  filter :budget
-  filter :description
-  filter :advice
+#  filter :budget
+#  filter :description
+#  filter :advice
   filter :holiday
   filter :parking
-  filter :home_page
-  filter :owner_id
-  filter :instagram
-  filter :twitter
-  filter :youtube
+#  filter :home_page
+#  filter :owner_id
+#  filter :instagram
+#  filter :twitter
+#  filter :youtube
   filter :status, as: :select, collection:Facility.statuses_i18n.invert.map{|key,value| [key, Facility.statuses[value]]}
-  filter :created_user
-  filter :updated_user
+#  filter :created_user
+#  filter :updated_user
   filter :opening_hours
 end

--- a/app/admin/facilities.rb
+++ b/app/admin/facilities.rb
@@ -114,7 +114,7 @@ ActiveAdmin.register Facility do
   end
 
   # 絞り込み条件の項目設定
-  filter :type
+  filter :type, as: :select, collection:Facility.types_i18n.invert.map{|key,value| [key, Facility.types[value]]}
   filter :name
   filter :postal_code
   filter :address
@@ -133,7 +133,7 @@ ActiveAdmin.register Facility do
   filter :instagram
   filter :twitter
   filter :youtube
-  filter :status
+  filter :status, as: :select, collection:Facility.statuses_i18n.invert.map{|key,value| [key, Facility.statuses[value]]}
   filter :created_user
   filter :updated_user
   filter :opening_hours

--- a/app/admin/facility_images.rb
+++ b/app/admin/facility_images.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register FacilityImage do
   index do
     selectable_column
     column :image do |r|
-      link_to image_tag(r.image.thumb.url, class: 'image-thumbnail'), 
+      link_to image_tag(r.image.thumb.url, class: 'image-thumbnail'),
         admin_facility_facility_image_path(r.facility_id, r.id)  if r.image.url
     end
     id_column
@@ -28,7 +28,7 @@ ActiveAdmin.register FacilityImage do
       row :updated_at
     end
   end
-  
+
   form do |f|
     f.semantic_errors *f.object.errors.keys
     f.inputs do
@@ -38,4 +38,8 @@ ActiveAdmin.register FacilityImage do
     end
     f.actions
   end
+
+  # 絞り込み条件の項目設定
+  filter :order
+  filter :created_user
 end

--- a/app/admin/facility_images.rb
+++ b/app/admin/facility_images.rb
@@ -41,5 +41,4 @@ ActiveAdmin.register FacilityImage do
 
   # 絞り込み条件の項目設定
   filter :order
-  filter :created_user
 end

--- a/app/admin/inquiries.rb
+++ b/app/admin/inquiries.rb
@@ -2,8 +2,8 @@ ActiveAdmin.register Inquiry do
   # 管理画面で新規作成、削除を表示させない
   actions :all, except: [:new, :destroy]
   # 検索条件パネルの表示項目
-  filter :status
-  filter :kind
+  filter :status, as: :select, collection:Inquiry.statuses_i18n.invert.map{|key,value| [key, Inquiry.statuses[value]]}
+  filter :kind, as: :select, collection:Inquiry.kinds_i18n.invert.map{|key,value| [key, Inquiry.kinds[value]]}
   filter :name
   filter :email
   filter :subject

--- a/app/admin/inquiries.rb
+++ b/app/admin/inquiries.rb
@@ -2,7 +2,15 @@ ActiveAdmin.register Inquiry do
   # 管理画面で新規作成、削除を表示させない
   actions :all, except: [:new, :destroy]
   # 検索条件パネルの表示項目
-  filter :status, as: :select
+  filter :status, as: :select, collection:Inquiry.statuses_i18n.invert
+  filter :kind, as: :select, collection:Inquiry.kinds_i18n.invert
+  filter :name
+  filter :email
+  filter :subject
+  filter :message
+  filter :created_at
+  filter :updated_at
+
   # 管理画面で更新できる項目の設定
   permit_params :status, :admin_comment
 
@@ -14,10 +22,10 @@ ActiveAdmin.register Inquiry do
     column(:kind) do |inquiry|
       inquiry.kind_i18n
     end
-    column :user_id
     column :name
-    column :facility_id
+    column :email
     column :subject
+    column :message
     column :created_at
     column :updated_at
     actions
@@ -31,7 +39,7 @@ ActiveAdmin.register Inquiry do
       input :user_id, input_html: { disabled: true }
       input :name, input_html: { disabled: true }
       input :email, input_html: { disabled: true }
-      input :facility_id, input_html: { disabled: true }  
+      input :facility_id, input_html: { disabled: true }
       input :subject, input_html: { disabled: true }
       input :message, as: :text, input_html: { disabled: true }
       input :created_at, as: :string, input_html: { disabled: true }
@@ -40,4 +48,5 @@ ActiveAdmin.register Inquiry do
     end
     f.actions
   end
+
 end

--- a/app/admin/inquiries.rb
+++ b/app/admin/inquiries.rb
@@ -7,9 +7,9 @@ ActiveAdmin.register Inquiry do
   filter :name
   filter :email
   filter :subject
-  filter :message
+#  filter :message
   filter :created_at
-  filter :updated_at
+#  filter :updated_at
 
   # 管理画面で更新できる項目の設定
   permit_params :status, :admin_comment
@@ -22,12 +22,14 @@ ActiveAdmin.register Inquiry do
     column(:kind) do |inquiry|
       inquiry.kind_i18n
     end
+    column :user_id
     column :name
+    column :facility_id
     column :email
     column :subject
-    column :message
+#    column :message
     column :created_at
-    column :updated_at
+#    column :updated_at
     actions
   end
 

--- a/app/admin/inquiries.rb
+++ b/app/admin/inquiries.rb
@@ -2,8 +2,8 @@ ActiveAdmin.register Inquiry do
   # 管理画面で新規作成、削除を表示させない
   actions :all, except: [:new, :destroy]
   # 検索条件パネルの表示項目
-  filter :status, as: :select, collection:Inquiry.statuses_i18n.invert
-  filter :kind, as: :select, collection:Inquiry.kinds_i18n.invert
+  filter :status
+  filter :kind
   filter :name
   filter :email
   filter :subject

--- a/app/admin/menus.rb
+++ b/app/admin/menus.rb
@@ -13,7 +13,7 @@ ActiveAdmin.register Menu do
     id_column
     column :name
     column :price
-    column :content
+#    column :content
     column :order
     actions
   end
@@ -49,4 +49,8 @@ ActiveAdmin.register Menu do
     end
     f.actions
   end
+
+  # 絞り込み条件の項目設定
+  filter :name
+  filter :price
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -14,6 +14,7 @@ ActiveAdmin.register User do
       f.input :image
       f.input :role,  as: :select, collection:User.roles_i18n.invert
       f.input :profile
+      f.input :status,  as: :select, collection:User.statuses_i18n.invert
       f.input :mailmagazine
     end
     f.actions
@@ -35,6 +36,9 @@ ActiveAdmin.register User do
       user.role_i18n
     end
     column :profile
+    column(:status) do |user|
+      user.status_i18n
+    end
     column :mailmagazine
     actions # 後述するpermit_paramsの設定に応じて閲覧編集削除などのリンクを表示
   end
@@ -57,6 +61,9 @@ ActiveAdmin.register User do
         user.role_i18n
       end
       row :profile
+      row(:status) do |user|
+        user.status_i18n
+      end
       row :mailmagazine
     end
   end
@@ -66,12 +73,11 @@ ActiveAdmin.register User do
   filter :email
   filter :nickname
   filter :birth_year
-  filter :sex
+  filter :sex, as: :select, collection:User.sexes_i18n.invert.map{|key,value| [key, User.sexes[value]]}
   filter :prefecture
   filter :image
-  filter :role
+  filter :role, as: :select, collection:User.roles_i18n.invert.map{|key,value| [key, User.roles[value]]}
   filter :profile
-  filter :status
-  filter :created_at
-  filter :update_at
+  filter :status, as: :select, collection:User.statuses_i18n.invert.map{|key,value| [key, User.statuses[value]]}
+  filter :mailmagazine
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -61,4 +61,18 @@ ActiveAdmin.register User do
       row :mailmagazine
     end
   end
+
+  # 絞り込み条件の項目設定
+  filter :type
+  filter :email
+  filter :nickname
+  filter :birth_year
+  filter :sex
+  filter :prefecture
+  filter :image
+  filter :role
+  filter :profile
+  filter :status
+  filter :created_at
+  filter :update_at
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -24,7 +24,6 @@ ActiveAdmin.register User do
     selectable_column
     id_column
     column :email
-    column :password
     column :nickname
     column :birth_year
     column(:sex) do |user|

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -31,11 +31,13 @@ ActiveAdmin.register User do
       user.sex_i18n
     end
     column :prefecture
-    column :image
+    column :image do |r|
+      image_tag(r.image.url, class: 'image-thumbnail') if r.image.url
+    end
     column(:role) do |user|
       user.role_i18n
     end
-    column :profile
+#    column :profile
     column(:status) do |user|
       user.status_i18n
     end
@@ -56,7 +58,9 @@ ActiveAdmin.register User do
         user.sex_i18n
       end
       row :prefecture
-      row :image
+      row :image do |r|
+        image_tag(r.image.url, class: 'image-thumbnail') if r.image.url
+      end
       row(:role) do |user|
         user.role_i18n
       end
@@ -74,10 +78,10 @@ ActiveAdmin.register User do
   filter :nickname
   filter :birth_year
   filter :sex, as: :select, collection:User.sexes_i18n.invert.map{|key,value| [key, User.sexes[value]]}
-  filter :prefecture
-  filter :image
+  filter :prefecture, as: :select, collection:User.prefectures_i18n.invert.map{|key,value| [key, User.prefectures[value]]}
+#  filter :image
   filter :role, as: :select, collection:User.roles_i18n.invert.map{|key,value| [key, User.roles[value]]}
-  filter :profile
+#  filter :profile
   filter :status, as: :select, collection:User.statuses_i18n.invert.map{|key,value| [key, User.statuses[value]]}
   filter :mailmagazine
 end

--- a/app/assets/stylesheets/admin/active_admin.scss
+++ b/app/assets/stylesheets/admin/active_admin.scss
@@ -22,3 +22,7 @@
 .image-preview{
   margin: 2px;
 }
+
+.facility-link-width{
+  width: 80px;
+}

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -39,6 +39,10 @@ ja:
       facility_image: "施設画像"
 
     attributes:
+      admin_user:
+        email: "メールアドレス"
+        created_at: 作成日時
+
       user:
         current_password: "現在のパスワード"
         email: "メールアドレス"
@@ -83,6 +87,8 @@ ja:
         created_user: "作成者ID"
         updated_user: "更新者ID"
         user_id: "ユーザーID"
+        opening_hours: "開店時間"
+
       inquiry:
         id: 問い合わせ番号
         status: ステータス
@@ -129,7 +135,7 @@ ja:
     - 金
     - 土
     abbr_month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -155,7 +161,7 @@ ja:
       long: "%Y年%m月%d日(%a)"
       short: "%m/%d"
     month_names:
-    - 
+    -
     - 1月
     - 2月
     - 3月
@@ -317,6 +323,3 @@ ja:
       long: "%Y/%m/%d %H:%M"
       short: "%m/%d %H:%M"
     pm: 午後
-
-
-

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,10 @@ ja:
         general: 一般
         owner: オーナー
         admin: 管理者
+      status:
+        temporary: 仮登録
+        active: 本登録
+        resign: 退会
     facility:
       type:
         spot: 観光スポット

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -92,7 +92,8 @@ ja:
         updated_user: "更新者ID"
         user_id: "ユーザーID"
         opening_hours: "開店時間"
-
+        facility_images: "施設画像"
+        menu: "メニュー"
       inquiry:
         id: 問い合わせ番号
         status: ステータス


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
管理画面の絞込項目の修正 #297

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- 管理者画面の絞り込みメニューの修正(全般)
- 管理者画面の表示不要な項目の削除(管理者、問い合わせ、ユーザー)

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/61322479/101763720-84ed4080-3b22-11eb-8c53-983a21187eaf.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/101763730-89b1f480-3b22-11eb-9496-363da09999ef.png" width="320"/>
<img src="https://user-images.githubusercontent.com/61322479/101763884-b960fc80-3b22-11eb-83d1-e08298295c87.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/101763887-bb2ac000-3b22-11eb-8938-402f9d2b889a.png" width="320"/>
<img src="https://user-images.githubusercontent.com/61322479/101763935-cf6ebd00-3b22-11eb-994c-b2e812345360.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/101763951-d3024400-3b22-11eb-8ca8-251fc0095fca.png" width="320"/>
<img src="https://user-images.githubusercontent.com/61322479/101764046-f200d600-3b22-11eb-9e22-eb305fc8377e.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/101764053-f3ca9980-3b22-11eb-9f68-1f2d98b5ac35.png" width="320"/>

## 懸念点
検索条件にenum値を反映させようと試みていますが、絞り込みが上手くいかなくなります。

(例)
問い合わせの「ステータス」に「1(進行中)」を入力して絞り込みを実施。➡︎検索条件が反映される。

inquiries.rb
```
filter :status
```

問い合わせの「ステータス」にenum値を反映させ、「進行中」を選択して絞り込みを実施。➡︎検索条件が反映されず、未実施の内容が表示される。(未実施の内容のみ表示され、進行中の内容が表示されなくなる。)

inquiries.rb
```
filter :status, as: :select, collection:Inquiry.statuses_i18n.invert
```

上記現象のため、現在検索条件にenum値を反映させる実装は控えております。
enum値での絞り込みも正常動作できるようになりましたら反映致します。