### PR TITLE
ユーザプロフィルールの最大幅変更＆ヘッダーのユーザ画像表示

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -212,6 +212,10 @@ a:hover {
 
 
 // ========ここから（ヘッダー部）=========
+$header-height: 55px;
+$header-height-md: 72px;
+
+
 .header{
   background-color: #fff;
 }
@@ -269,6 +273,19 @@ nav.navbar{
   &.close-icon{
     width: 70%;
   }
+}
+
+.header-user-image{
+  position: absolute;
+  top: 7.5%;
+  left: 7.5%;
+  width: $header-height * 0.85;
+  height: $header-height * 0.85;
+  @media(min-width: 768px){
+    width: $header-height-md * 0.85;
+    height: $header-height-md * 0.85;
+  }
+  border-radius: 50%;
 }
 
 .logo-area{

--- a/app/assets/stylesheets/main/users.scss
+++ b/app/assets/stylesheets/main/users.scss
@@ -38,6 +38,10 @@
   margin-right: 15px;
 }
 
+.user-top.container{
+  max-width: 780px;
+}
+
 .list-content {
   float: left;
 }

--- a/app/views/publics/_header.html.erb
+++ b/app/views/publics/_header.html.erb
@@ -16,7 +16,11 @@
     <div class="account-icon-area">
         <% if user_signed_in?	%>
           <%= link_to user_path do %>
-            <%= image_tag('icon_account.svg', class:'header-icon') %>
+            <% if current_user.image.url %>
+              <%= image_tag current_user.image.url ,class:"header-user-image" %>
+            <% else %>
+              <%= image_tag('icon_account.svg', class:'header-icon') %>
+            <% end %>
           <% end %>
         <% else %>
           <%= link_to new_user_session_path do %>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
- ユーザプロフィルールの最大幅設定（780px)
- ヘッダーのユーザ画像を表示

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- ユーザプロフィルールの最大幅設定（780px)
- ログイン時に、プロフィルー画像が登録されている場合、ヘッダーにユーザ画像を表示

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->

before | after
---- | ----
<img src="https://user-images.githubusercontent.com/36526480/101798984-f4792500-3b4e-11eb-92b6-f735b780c2d4.png" width="320"/> | <img src="https://user-images.githubusercontent.com/36526480/101798989-f5aa5200-3b4e-11eb-80f1-af8a377ab2cd.png" width="320"/>
