### PR TITLE
Map repair

### DIFF
--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -130,7 +130,7 @@
     </div>
     <div class="google-map text-center">
 <!--      <div class="w-100" id="map" data-facility-latitude="<%= @facility.latitude %>" data-facility-longitude="<%= @facility.longitude %>">google map</div> -->
-      <iframe src="https://maps.google.co.jp/maps?output=embed&q=<%= @facility.name %> <%= @facility.address %>&z=16" width="800" height="600" frameborder="0" scrolling="no" ></iframe>
+        <iframe src="https://maps.google.co.jp/maps?output=embed&q=<%= @facility.name %> <%= @facility.address %>&z=16" class="w-100" id="map" frameborder="0" scrolling="no" ></iframe>
     </div>
   </div>
 </div>

--- a/app/views/facilities/show.html.erb
+++ b/app/views/facilities/show.html.erb
@@ -123,8 +123,8 @@
           <p class="information-list-content"><%= @facility.parking %></p>
         </li>
         <li class="information-list">
-          <p class="information-list-title">URL</p>
-          <p class="information-list-content"><%= link_to(@facility.home_page, @facility.home_page, target: :_blank) %></p>
+          <p class="information-list-title">ホームページ</p>
+          <p class="information-list-content"><%= link_to(@facility.name, @facility.home_page, target: :_blank) %></p>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## 目的
<!--実装の目的を一文ぐらいで-->
スマホ画面でGoogle mapの幅・高さが最適化されない現象の修正

## やったこと
<!-- 実装の技術的な内容を箇条書きで -->
- ブラウザのサイズごとにGoogle mapの幅・高さを最適化する設定を追加

## 変更前後の画像
<!-- UIの変更前後の画像を入れる（UIに変更があった場合） -->
before | after
---- | ----
<img src="https://user-images.githubusercontent.com/61322479/103001270-fc35c200-456f-11eb-8b36-8329207b4ccf.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/103001273-ffc94900-456f-11eb-94f7-f13f99d0d444.png" width="320"/>
<img src="https://user-images.githubusercontent.com/61322479/103001271-fdff8580-456f-11eb-8e17-83f749da6483.png" width="320"/> | <img src="https://user-images.githubusercontent.com/61322479/103001319-1a032700-4570-11eb-9a74-435871790ffd.png" width="320"/>

## 懸念点
URLが改行されないのが気になります。
住所・アクセスは開業されているのに、なぜURLだけ改行されないのか調査中です。
![スクリーンショット 2020-12-23 22 46 20](https://user-images.githubusercontent.com/61322479/103001614-b6c5c480-4570-11eb-93e6-5cf488a468d7.png)
